### PR TITLE
Add cartesian space PD feedback for swing legs

### DIFF
--- a/robot_driver/include/robot_driver/inverse_dynamics.h
+++ b/robot_driver/include/robot_driver/inverse_dynamics.h
@@ -33,6 +33,12 @@ class InverseDynamicsController : public LegControllerTemplate {
   /// Prior grf_array
   Eigen::VectorXd last_grf_array_;
 
+  /// Swing leg kp in Cartesian frame for all legs
+  Eigen::VectorXd swing_kp_cart_vec_;
+
+  /// Swing leg kd in Cartesian frame for all legs
+  Eigen::VectorXd swing_kd_cart_vec_;
+
   /// GRF exponential filter constant
   const double grf_exp_filter_const_ = 1.0;  // 1.0 = no filtering
 };

--- a/robot_driver/include/robot_driver/inverse_dynamics.h
+++ b/robot_driver/include/robot_driver/inverse_dynamics.h
@@ -33,12 +33,6 @@ class InverseDynamicsController : public LegControllerTemplate {
   /// Prior grf_array
   Eigen::VectorXd last_grf_array_;
 
-  /// Swing leg kp in Cartesian frame for all legs
-  Eigen::VectorXd swing_kp_cart_vec_;
-
-  /// Swing leg kd in Cartesian frame for all legs
-  Eigen::VectorXd swing_kd_cart_vec_;
-
   /// GRF exponential filter constant
   const double grf_exp_filter_const_ = 1.0;  // 1.0 = no filtering
 };

--- a/robot_driver/include/robot_driver/leg_controller_template.h
+++ b/robot_driver/include/robot_driver/leg_controller_template.h
@@ -46,7 +46,8 @@ class LegControllerTemplate {
    * @param[in] kp Proportional gains
    * @param[in] kd Derivative gains
    */
-  virtual void setGains(std::vector<double> kp, std::vector<double> kd);
+  virtual void setGains(const std::vector<double> &kp,
+                        const std::vector<double> &kd);
 
   /**
    * @brief Set the desired stance and swing proportional and derivative gains
@@ -55,10 +56,12 @@ class LegControllerTemplate {
    * @param[in] swing_kp Swing phase proportional gains
    * @param[in] swing_kd Swing phase derivative gains
    */
-  virtual void setGains(std::vector<double> stance_kp,
-                        std::vector<double> stance_kd,
-                        std::vector<double> swing_kp,
-                        std::vector<double> swing_kd);
+  virtual void setGains(const std::vector<double> &stance_kp,
+                        const std::vector<double> &stance_kd,
+                        const std::vector<double> &swing_kp,
+                        const std::vector<double> &swing_kd,
+                        const std::vector<double> &swing_kp_cart,
+                        const std::vector<double> &swing_kd_cart);
 
   /**
    * @brief Compute the leg command array message for a given current state and
@@ -92,6 +95,10 @@ class LegControllerTemplate {
   /// PD gain when foot is in swing
   std::vector<double> swing_kp_;
   std::vector<double> swing_kd_;
+
+  /// PD gain when foot is in swing (Cartesian)
+  std::vector<double> swing_kp_cart_;
+  std::vector<double> swing_kd_cart_;
 
   /// Last local plan message
   quad_msgs::RobotPlan::ConstPtr last_local_plan_msg_;

--- a/robot_driver/include/robot_driver/robot_driver.h
+++ b/robot_driver/include/robot_driver/robot_driver.h
@@ -289,6 +289,10 @@ class RobotDriver {
   std::vector<double> swing_kp_;
   std::vector<double> swing_kd_;
 
+  /// PD gain when foot is in swing (Cartesian)
+  std::vector<double> swing_kp_cart_;
+  std::vector<double> swing_kd_cart_;
+
   /// Define standing joint angles
   std::vector<double> stand_joint_angles_;
 

--- a/robot_driver/robot_driver.yaml
+++ b/robot_driver/robot_driver.yaml
@@ -13,10 +13,10 @@ robot_driver:
   stand_kd: [1, 1, 1]
   stance_kp: [10, 10, 10]
   stance_kd: [1, 1, 1]
-  # stance_kp: [0, 0, 0]
-  # stance_kd: [0, 0, 0]
   swing_kp: [10, 10, 10]
   swing_kd: [1, 1, 1]
+  swing_kp_cart: [200, 200, 200] # N/m
+  swing_kd_cart: [5, 5, 5]       # N/m
   safety_kp: [0, 0, 0]
   safety_kd: [2, 2, 2]
   stand_joint_angles: [0.0, 0.76, 1.52]

--- a/robot_driver/src/leg_controller_template.cpp
+++ b/robot_driver/src/leg_controller_template.cpp
@@ -20,20 +20,24 @@ void LegControllerTemplate::setGains(double kp, double kd) {
   swing_kd_ = kd_vec;
 }
 
-void LegControllerTemplate::setGains(std::vector<double> kp,
-                                     std::vector<double> kd) {
+void LegControllerTemplate::setGains(const std::vector<double> &kp,
+                                     const std::vector<double> &kd) {
   stance_kp_ = kp;
   stance_kd_ = kd;
   swing_kp_ = kp;
   swing_kd_ = kd;
 }
 
-void LegControllerTemplate::setGains(std::vector<double> stance_kp,
-                                     std::vector<double> stance_kd,
-                                     std::vector<double> swing_kp,
-                                     std::vector<double> swing_kd) {
+void LegControllerTemplate::setGains(const std::vector<double> &stance_kp,
+                                     const std::vector<double> &stance_kd,
+                                     const std::vector<double> &swing_kp,
+                                     const std::vector<double> &swing_kd,
+                                     const std::vector<double> &swing_kp_cart,
+                                     const std::vector<double> &swing_kd_cart) {
   stance_kp_ = stance_kp;
   stance_kd_ = stance_kd;
   swing_kp_ = swing_kp;
   swing_kd_ = swing_kd;
+  swing_kp_cart_ = swing_kp_cart;
+  swing_kd_cart_ = swing_kd_cart;
 }

--- a/robot_driver/src/robot_driver.cpp
+++ b/robot_driver/src/robot_driver.cpp
@@ -48,6 +48,8 @@ RobotDriver::RobotDriver(ros::NodeHandle nh, int argc, char** argv) {
   quad_utils::loadROSParam(nh_, "robot_driver/stance_kd", stance_kd_);
   quad_utils::loadROSParam(nh_, "robot_driver/swing_kp", swing_kp_);
   quad_utils::loadROSParam(nh_, "robot_driver/swing_kd", swing_kd_);
+  quad_utils::loadROSParam(nh_, "robot_driver/swing_kp_cart", swing_kp_cart_);
+  quad_utils::loadROSParam(nh_, "robot_driver/swing_kd_cart", swing_kd_cart_);
   quad_utils::loadROSParam(nh_, "robot_driver/safety_kp", safety_kp_);
   quad_utils::loadROSParam(nh_, "robot_driver/safety_kd", safety_kd_);
   quad_utils::loadROSParam(nh_, "robot_driver/stand_joint_angles",
@@ -109,7 +111,8 @@ RobotDriver::RobotDriver(ros::NodeHandle nh, int argc, char** argv) {
                                               << ", returning nullptr");
     leg_controller_ = nullptr;
   }
-  leg_controller_->setGains(stance_kp_, stance_kd_, swing_kp_, swing_kd_);
+  leg_controller_->setGains(stance_kp_, stance_kd_, swing_kp_, swing_kd_,
+                            swing_kp_cart_, swing_kd_cart_);
 
   // Start sitting
   control_mode_ = SIT;


### PR DESCRIPTION
Adds Cartesian space PD during swing in the inverse dynamics controller. Setting the gains to zero yields the same system as before. We can discuss if these gains should be added in stance as well, or if any special damping should be included. Preliminary testing seems to indicate better foot tracking when near singular configurations.

Also threw in a few refactors of robot driver (removing commented code, added const ref arguments to a few functions).