### PR TITLE
Add permissions to doxygen action and remove PRs from action triggers

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -6,14 +6,13 @@ on:
       - main
       - devel
       - melodic_devel_gh_pages_doxygen_updates
-  pull_request:
-    branches:
-      - main
   page_build:
 
 jobs:
   doxygen:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v1
       - name: Build documentation


### PR DESCRIPTION
Doxygen action should only trigger on pushes to devel and main now.