### PR TITLE
rosdep installation switch, a1 model update, qpOASES removal, IPOPT quick fix

### DIFF
--- a/external/setup_deps.sh
+++ b/external/setup_deps.sh
@@ -16,7 +16,7 @@ mkdir coinbrew
 cd coinbrew
 wget https://raw.githubusercontent.com/coin-or/coinbrew/v1.0/coinbrew
 chmod u+x coinbrew
-./coinbrew fetch Ipopt --latest-release --no-prompt
+./coinbrew fetch Ipopt@3.13 --no-prompt
 cd ..
 if [ -d "./coinhsl" ] 
 then

--- a/global_body_planner/include/global_body_planner/global_body_plan.h
+++ b/global_body_planner/include/global_body_planner/global_body_plan.h
@@ -112,7 +112,7 @@ class GlobalBodyPlan {
    * @brief Set the timestamp at which this plan was published
    * @param[in] timestamp Timestamp at which the plan was published
    */
-  inline double setPublishedTimestamp(ros::Time timestamp) {
+  inline void setPublishedTimestamp(ros::Time timestamp) {
     published_timestamp_ = timestamp;
   }
 

--- a/global_body_planner/package.xml
+++ b/global_body_planner/package.xml
@@ -68,13 +68,10 @@
   <exec_depend>grid_map_core</exec_depend>
   <exec_depend>grid_map_ros</exec_depend>
 
-
-  <!-- switching from setup_deps.sh to rosdeps here-->
   <depend>tf</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>grid_map</depend>
-
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/global_body_planner/package.xml
+++ b/global_body_planner/package.xml
@@ -69,6 +69,13 @@
   <exec_depend>grid_map_ros</exec_depend>
 
 
+  <!-- switching from setup_deps.sh to rosdeps here-->
+  <depend>tf</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>grid_map</depend>
+
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/global_body_planner/setup_deps.sh
+++ b/global_body_planner/setup_deps.sh
@@ -1,6 +1,0 @@
-#sudo apt install -y ros-melodic-tf
-#sudo apt install -y ros-melodic-tf2
-#sudo apt install -y ros-melodic-tf2-geometry-msgs
-#sudo apt install -y ros-melodic-grid-map
-
-# moving to package.xml using rosdep

--- a/global_body_planner/setup_deps.sh
+++ b/global_body_planner/setup_deps.sh
@@ -1,4 +1,6 @@
-sudo apt install -y ros-melodic-tf
-sudo apt install -y ros-melodic-tf2
-sudo apt install -y ros-melodic-tf2-geometry-msgs
-sudo apt install -y ros-melodic-grid-map
+#sudo apt install -y ros-melodic-tf
+#sudo apt install -y ros-melodic-tf2
+#sudo apt install -y ros-melodic-tf2-geometry-msgs
+#sudo apt install -y ros-melodic-grid-map
+
+# moving to package.xml using rosdep

--- a/local_planner/CMakeLists.txt
+++ b/local_planner/CMakeLists.txt
@@ -28,11 +28,6 @@ find_package(Eigen3 REQUIRED)
 # find_package(OsqpEigen REQUIRED)
 find_package(PythonLibs 2.7)
 
-set(QPOASES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external/qpOASES")
-set(QPOASES_INCLUDE_DIRS "${QPOASES_DIR}/include")
-set(QPOASES_LIBRARIES "${QPOASES_DIR}/build/libs")
-find_library(QPOASES NAMES qpOASES PATHS ${QPOASES_LIBRARIES} REQUIRED)
-
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS roscpp std_msgs quad_msgs quad_utils grid_map_core grid_map_ros eigen_conversions nmpc_controller
@@ -50,7 +45,6 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIRS}
-  ${QPOASES_INCLUDE_DIRS}
   ${PYTHON_INCLUDE_DIRS}
   /usr/local/include/coin-or
 )

--- a/quad_simulator/a1_description/package.xml
+++ b/quad_simulator/a1_description/package.xml
@@ -10,14 +10,14 @@
     <buildtool_depend>catkin</buildtool_depend>
     <depend>roscpp</depend>
     <depend>std_msgs</depend>
-    <depend>controller-manager</depend>
-    <depend>joint-state-controller</depend>
-    <depend>gazebo-ros-pkgs</depend>
-    <depend>ros-control</depend>
-    <depend>gazebo-ros-control</depend>
-    <depend>effort-controllers</depend>
-    <depend>robot-state-publisher</depend>
-    <depend>imu-tools</depend>
-    <depend>message-to-tf</depend>
+    <depend>controller_manager</depend>
+    <depend>joint_state_controller</depend>
+    <depend>gazebo_ros_pkgs</depend>
+    <depend>ros_control</depend>
+    <depend>gazebo_ros_control</depend>
+    <depend>effort_controllers</depend>
+    <depend>robot_state_publisher</depend>
+    <depend>imu_tools</depend>
+    <depend>message_to_tf</depend>
 
 </package>

--- a/quad_simulator/a1_description/package.xml
+++ b/quad_simulator/a1_description/package.xml
@@ -10,8 +10,6 @@
     <buildtool_depend>catkin</buildtool_depend>
     <depend>roscpp</depend>
     <depend>std_msgs</depend>
-
-    <!-- from ../setup_deps.sh -->
     <depend>controller-manager</depend>
     <depend>joint-state-controller</depend>
     <depend>gazebo-ros-pkgs</depend>

--- a/quad_simulator/a1_description/package.xml
+++ b/quad_simulator/a1_description/package.xml
@@ -11,4 +11,15 @@
     <depend>roscpp</depend>
     <depend>std_msgs</depend>
 
+    <!-- from ../setup_deps.sh -->
+    <depend>controller-manager</depend>
+    <depend>joint-state-controller</depend>
+    <depend>gazebo-ros-pkgs</depend>
+    <depend>ros-control</depend>
+    <depend>gazebo-ros-control</depend>
+    <depend>effort-controllers</depend>
+    <depend>robot-state-publisher</depend>
+    <depend>imu-tools</depend>
+    <depend>message-to-tf</depend>
+
 </package>

--- a/quad_simulator/a1_description/sdf_mesh/a1.sdf
+++ b/quad_simulator/a1_description/sdf_mesh/a1.sdf
@@ -68,7 +68,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/trunk.dae</uri>
+            <uri>model:///meshes/trunk.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -154,7 +154,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/hip.dae</uri>
+            <uri>model:///meshes/hip.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -228,7 +228,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/thigh_mirror.dae</uri>
+            <uri>model:///meshes/thigh_mirror.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -300,7 +300,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/calf.dae</uri>
+            <uri>model:///meshes/calf.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -465,7 +465,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/hip.dae</uri>
+            <uri>model:///meshes/hip.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -539,7 +539,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/thigh_mirror.dae</uri>
+            <uri>model:///meshes/thigh_mirror.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -611,7 +611,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/calf.dae</uri>
+            <uri>model:///meshes/calf.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -776,7 +776,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/hip.dae</uri>
+            <uri>model:///meshes/hip.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -850,7 +850,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/thigh.dae</uri>
+            <uri>model:///meshes/thigh.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -922,7 +922,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/calf.dae</uri>
+            <uri>model:///meshes/calf.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -1087,7 +1087,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/hip.dae</uri>
+            <uri>model:///meshes/hip.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -1161,7 +1161,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/thigh.dae</uri>
+            <uri>model:///meshes/thigh.dae</uri>
           </mesh>
         </geometry>
         <material>
@@ -1233,7 +1233,7 @@
         <geometry>
           <mesh>
             <scale>1 1 1</scale>
-            <uri>model://a1_description/meshes/calf.dae</uri>
+            <uri>model:///meshes/calf.dae</uri>
           </mesh>
         </geometry>
         <material>

--- a/quad_simulator/a1_description/sdf_mesh/model.config
+++ b/quad_simulator/a1_description/sdf_mesh/model.config
@@ -1,0 +1,6 @@
+
+<?xml version="1.0" ?>
+<model>
+	<name>a1</name>
+	<sdf version="1.5">a1.sdf</sdf>
+</model>

--- a/quad_simulator/gazebo_scripts/package.xml
+++ b/quad_simulator/gazebo_scripts/package.xml
@@ -71,6 +71,17 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+
+  <!-- from ../setup_deps.sh -->
+  <!--<depend>controller-manager</depend>-->
+  <!--<depend>joint-state-controller</depend>-->
+  <depend>gazebo-ros-pkgs</depend>
+  <depend>ros-control</depend>
+  <depend>gazebo-ros-control</depend>
+  <depend>effort-controllers</depend>
+  <!--<depend>robot-state-publisher</depend>-->
+  <depend>imu-tools</depend>
+  <depend>message-to-tf</depend>
   
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/quad_simulator/gazebo_scripts/package.xml
+++ b/quad_simulator/gazebo_scripts/package.xml
@@ -72,12 +72,12 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
 
-  <depend>gazebo-ros-pkgs</depend>
-  <depend>ros-control</depend>
-  <depend>gazebo-ros-control</depend>
-  <depend>effort-controllers</depend>
-  <depend>imu-tools</depend>
-  <depend>message-to-tf</depend>
+  <depend>gazebo_ros_pkgs</depend>
+  <depend>ros_control</depend>
+  <depend>gazebo_ros_control</depend>
+  <depend>effort_controllers</depend>
+  <depend>imu_tools</depend>
+  <depend>message_to_tf</depend>
   
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/quad_simulator/gazebo_scripts/package.xml
+++ b/quad_simulator/gazebo_scripts/package.xml
@@ -72,14 +72,10 @@
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
 
-  <!-- from ../setup_deps.sh -->
-  <!--<depend>controller-manager</depend>-->
-  <!--<depend>joint-state-controller</depend>-->
   <depend>gazebo-ros-pkgs</depend>
   <depend>ros-control</depend>
   <depend>gazebo-ros-control</depend>
   <depend>effort-controllers</depend>
-  <!--<depend>robot-state-publisher</depend>-->
   <depend>imu-tools</depend>
   <depend>message-to-tf</depend>
   

--- a/quad_simulator/setup_deps.sh
+++ b/quad_simulator/setup_deps.sh
@@ -1,4 +1,4 @@
-GAZEBO_MODEL_PATH_UPDATE="export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:$(pwd)/spirit_description:$(pwd)/other/sensor_description:$(pwd)/other/objects_description:$(pwd)/gazebo_scripts/worlds"
+GAZEBO_MODEL_PATH_UPDATE="export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:$(pwd)/spirit_description:$(pwd)/a1_description:$(pwd)/other/sensor_description:$(pwd)/other/objects_description:$(pwd)/gazebo_scripts/worlds"
 
 if grep "$GAZEBO_MODEL_PATH_UPDATE" ~/.bashrc > /dev/null
 then
@@ -15,13 +15,13 @@ sudo apt update
 sudo apt install -y gazebo9 -y
 
 
-
-sudo apt install -y ros-melodic-controller-manager -y
-sudo apt install -y ros-melodic-joint-state-controller -y
-sudo apt install -y ros-melodic-gazebo-ros-pkgs -y
-sudo apt install -y ros-melodic-ros-control -y
-sudo apt install -y ros-melodic-gazebo-ros-control -y
-sudo apt install -y ros-melodic-effort-controllers -y
-sudo apt install -y ros-melodic-robot-state-publisher -y
-sudo apt install -y ros-melodic-imu-tools -y
-sudo apt install -y ros-melodic-message-to-tf -y
+# moving to package.xml in a1_description, spirit_description, gazebo_scripts
+#sudo apt install -y ros-melodic-controller-manager -y
+#sudo apt install -y ros-melodic-joint-state-controller -y
+#sudo apt install -y ros-melodic-gazebo-ros-pkgs -y
+#sudo apt install -y ros-melodic-ros-control -y
+#sudo apt install -y ros-melodic-gazebo-ros-control -y
+#sudo apt install -y ros-melodic-effort-controllers -y
+#sudo apt install -y ros-melodic-robot-state-publisher -y
+#sudo apt install -y ros-melodic-imu-tools -y
+#sudo apt install -y ros-melodic-message-to-tf -y

--- a/quad_simulator/setup_deps.sh
+++ b/quad_simulator/setup_deps.sh
@@ -13,15 +13,3 @@ cat /etc/apt/sources.list.d/gazebo-stable.list
 wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt update
 sudo apt install -y gazebo9 -y
-
-
-# moving to package.xml in a1_description, spirit_description, gazebo_scripts
-#sudo apt install -y ros-melodic-controller-manager -y
-#sudo apt install -y ros-melodic-joint-state-controller -y
-#sudo apt install -y ros-melodic-gazebo-ros-pkgs -y
-#sudo apt install -y ros-melodic-ros-control -y
-#sudo apt install -y ros-melodic-gazebo-ros-control -y
-#sudo apt install -y ros-melodic-effort-controllers -y
-#sudo apt install -y ros-melodic-robot-state-publisher -y
-#sudo apt install -y ros-melodic-imu-tools -y
-#sudo apt install -y ros-melodic-message-to-tf -y

--- a/quad_simulator/spirit_description/package.xml
+++ b/quad_simulator/spirit_description/package.xml
@@ -50,6 +50,17 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <!-- from ../setup_deps.sh -->
+  <depend>controller-manager</depend>
+  <depend>joint-state-controller</depend>
+  <depend>gazebo-ros-pkgs</depend>
+  <depend>ros-control</depend>
+  <depend>gazebo-ros-control</depend>
+  <depend>effort-controllers</depend>
+  <depend>robot-state-publisher</depend>
+  <depend>imu-tools</depend>
+  <depend>message-to-tf</depend>
+
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/quad_simulator/spirit_description/package.xml
+++ b/quad_simulator/spirit_description/package.xml
@@ -50,7 +50,6 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- from ../setup_deps.sh -->
   <depend>controller-manager</depend>
   <depend>joint-state-controller</depend>
   <depend>gazebo-ros-pkgs</depend>

--- a/quad_simulator/spirit_description/package.xml
+++ b/quad_simulator/spirit_description/package.xml
@@ -50,15 +50,15 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>controller-manager</depend>
-  <depend>joint-state-controller</depend>
-  <depend>gazebo-ros-pkgs</depend>
-  <depend>ros-control</depend>
-  <depend>gazebo-ros-control</depend>
-  <depend>effort-controllers</depend>
-  <depend>robot-state-publisher</depend>
-  <depend>imu-tools</depend>
-  <depend>message-to-tf</depend>
+  <depend>controller_manager</depend>
+  <depend>joint_state_controller</depend>
+  <depend>gazebo_ros_pkgs</depend>
+  <depend>ros_control</depend>
+  <depend>gazebo_ros_control</depend>
+  <depend>effort_controllers</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>imu_tools</depend>
+  <depend>message_to_tf</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/quad_utils/package.xml
+++ b/quad_utils/package.xml
@@ -77,6 +77,9 @@
   <exec_depend>grid_map_ros</exec_depend>
   <exec_depend>grid_map_pcl</exec_depend>
 
+  <!-- moved from setup_deps.sh-->
+  <depend>plotjuggler_ros</depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/quad_utils/package.xml
+++ b/quad_utils/package.xml
@@ -77,7 +77,6 @@
   <exec_depend>grid_map_ros</exec_depend>
   <exec_depend>grid_map_pcl</exec_depend>
 
-  <!-- moved from setup_deps.sh-->
   <depend>plotjuggler_ros</depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/quad_utils/setup_deps.sh
+++ b/quad_utils/setup_deps.sh
@@ -1,4 +1,3 @@
 sudo apt install -y libeigen3-dev
 sudo apt install -y python-pygame
-#sudo apt install -y ros-melodic-plotjuggler-ros # moved to package.xml rosdep
 sudo apt install -y tmux

--- a/quad_utils/setup_deps.sh
+++ b/quad_utils/setup_deps.sh
@@ -1,4 +1,4 @@
 sudo apt install -y libeigen3-dev
 sudo apt install -y python-pygame
-sudo apt install -y ros-melodic-plotjuggler-ros
+#sudo apt install -y ros-melodic-plotjuggler-ros # moved to package.xml rosdep
 sudo apt install -y tmux


### PR DESCRIPTION
Removed unused qpOASES references and fixed a global body planner function return.

switched installs from apt to rosdep in global_body_planner and quad_utils

erroneous file removed

Merge branch 'melodic_devel_clean_install' of github.com:robomechanics/quad-software into melodic_devel_clean_install

switched quad simulator to install ros packages using rosdeps

Fixing a1 model (model.config, Gazebo path, .sdf paths)

Merge branch 'melodic_devel_clean_install' of github.com:robomechanics/quad-software into melodic_devel_clean_install

Quick fix after Ipopt new version.