### PR TITLE
Temporary fixes to #204 and #345 (local planner improvement when yaw wraps)

### DIFF
--- a/global_body_planner/global_body_planner.yaml
+++ b/global_body_planner/global_body_planner.yaml
@@ -2,15 +2,15 @@ global_body_planner:
   update_rate: 20                         # Update rate of the ROS node (in Hz)
   num_calls: 1                            # Number of times to call the planner
   max_planning_time: 0.20                 # Maximum amount of time to run the planner
-  goal_state: [5.0, 0.0]                  # Nominal goal state (x/y coordinates)
+  goal_state: [-1.0, 0.0]                  # Nominal goal state (x/y coordinates)
   pos_error_threshold: 25                 # Error from planned state to trigger reset
   startup_delay: 2.0                      # Time to delay after starting node before planning
   replanning: true                        # Boolean to determine if replanning is allowed
   dt: 0.03                                # Resolution of kinematic feasibility checks, m
   trapped_buffer_factor: 7                # Number of feasibility that must pass to not consider a state trapped
   backup_ratio: 0.5                       # Ratio of trajectory to back up after finding an invalid state, s
-  num_leap_samples: 10                    # Number of leap actions computed for each extend function
-  traversability_threshold: 0.3           # Traversability threshold for reachability point
+  num_leap_samples: 0                    # Number of leap actions computed for each extend function
+  traversability_threshold: 0.01           # Traversability threshold for reachability point
   mu: 0.25                                # Friction coefficient
   g: 9.81                                 # Gravity constant, m/s^2
   t_s_min: 0.12                           # Minimum stance time, s

--- a/local_planner/include/local_planner/local_planner.h
+++ b/local_planner/include/local_planner/local_planner.h
@@ -34,6 +34,12 @@ class LocalPlanner {
    */
   void spin();
 
+  /// Previous reference state in MPC (for unwrapping)
+  double prev_unwrapped_yaw;
+
+  /// Boolean of first reference plan
+  bool first_ref_plan;
+
  private:
   FRIEND_TEST(LocalPlannerTest, noInputCase);
 

--- a/local_planner/src/local_planner.cpp
+++ b/local_planner/src/local_planner.cpp
@@ -410,7 +410,7 @@ void LocalPlanner::getReference() {
   // horizon's last yaw state
   if (!first_ref_plan) {
     float diff = wrapped_yaw_ref[0] - prev_unwrapped_yaw;
-    float quotient = round(diff / (2 * M_PI));
+    float quotient = abs(round(diff / (2 * M_PI)));
     if (diff > M_PI) {
       wrapped_yaw_ref[0] = wrapped_yaw_ref[0] - quotient * 2 * M_PI;
     } else if (diff < -M_PI) {
@@ -431,21 +431,21 @@ void LocalPlanner::getReference() {
   ref_body_plan_.col(5) = eig_unwrapped_yaw_ref;
 
   // Update current state with unwrapped yaw
-
   float diff_curr_state =
       current_state_(5) -
       unwrapped_yaw_ref[0];  // If current state and unwrapped yaw reference
                              // large, then correct wrapped current state
-  // float diff_curr_state = current_state_(5) - unwrapped_yaw_ref[N_ - 1];
 
   // ROS_INFO_THROTTLE(0.5, "Current state yaw %0.5f", current_state_(5));
-  float quotient_curr_state = round(diff_curr_state / (2 * M_PI));
+  float quotient_curr_state = abs(round(diff_curr_state / (2 * M_PI)));
   if (diff_curr_state > M_PI) {
     // ROS_WARN("CURR STATE: DIFF > M_PI");
     // ROS_INFO("Current state yaw %0.2f", current_state_(5));
     // ROS_INFO("Unwrapped Yaw Reference %0.2f", unwrapped_yaw_ref[0]);
     // ROS_INFO("diff curr state: %0.2f", diff_curr_state);
+    // ROS_INFO("quotient: %0.2f", quotient_curr_state);
     current_state_(5) = current_state_(5) - quotient_curr_state * 2 * M_PI;
+    // ROS_INFO("Unwrapped current state yaw %0.2f", current_state_(5));
   } else if (diff_curr_state < -M_PI) {
     // ROS_WARN("CURR STATE: DIFF < M_PI");
     // ROS_INFO("diff curr state: %0.2f", diff_curr_state);

--- a/local_planner/src/local_planner.cpp
+++ b/local_planner/src/local_planner.cpp
@@ -108,7 +108,7 @@ LocalPlanner::LocalPlanner(ros::NodeHandle nh)
   current_plan_index_ = 0;
 
   // Initialized reference plan for yaw
-  first_ref_plan = false;
+  first_ref_plan = true;
 }
 
 void LocalPlanner::initLocalBodyPlanner() {

--- a/quad_utils/include/quad_utils/math_utils.h
+++ b/quad_utils/include/quad_utils/math_utils.h
@@ -140,13 +140,15 @@ std::vector<double> centralDiff(std::vector<double> data, double dt);
  * @return Vector of unwrapped signal
  */
 std::vector<double> unwrap(std::vector<double> data);
+// template <typename VectorType>
+// VectorType unwrap(const VectorType& data);
 
 /**
  * @brief Selective damping least square matrix inverse
  * @param[in] jacobian Input matrix
  * @return Pseudo-inverse of the input matrix
  */
-Eigen::MatrixXd sdlsInv(const Eigen::MatrixXd &jacobian);
+Eigen::MatrixXd sdlsInv(const Eigen::MatrixXd& jacobian);
 }  // namespace math_utils
 
 #endif  // QUAD_MATH_UTILS_H

--- a/quad_utils/launch/quad_gazebo.launch
+++ b/quad_utils/launch/quad_gazebo.launch
@@ -8,6 +8,7 @@
   <arg name="dash" default="false" />
   <arg name="world" default="flat" />
   <arg name="logging" default="false" />
+  <arg name="init_pose" default="-x 0.0 -y 0.0 -z 0.5 -Y 0.0" />
   <param name="/use_sim_time" value="true" />
 
   <!-- Launch the Quad world with specific physics parameters -->
@@ -34,7 +35,7 @@
     <include file="$(find quad_utils)/launch/quad_spawn.launch">
       <arg name="robot_type" value="$(arg robot_type)" />
       <arg name="controller" default="$(arg controller)" />
-      <arg name="init_pose" value="-x 0.0 -y 0.0 -z 0.5" />
+      <arg name="init_pose" value="$(arg init_pose)" />
       <arg name="namespace" value="robot_1" />
     </include>
     <param name="robot_type" value="$(arg robot_type)" />
@@ -50,7 +51,7 @@
       <include file="$(find quad_utils)/launch/quad_spawn.launch">
         <arg name="robot_type" value="$(arg robot_type)" />
         <arg name="controller" default="$(arg controller)" />
-        <arg name="init_pose" value="-x 0.0 -y 1.0 -z 0.5" />
+        <arg name="init_pose" value="-x 0.0 -y 1.0 -z 0.5 -Y 0.0" />
         <arg name="namespace" value="robot_2" />
       </include>
       <param name="robot_type" value="$(arg robot_type)" />

--- a/quad_utils/launch/quad_spawn.launch
+++ b/quad_utils/launch/quad_spawn.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="controller"    default="inverse_dynamics"/>
-  <arg name="init_pose"     default="-x 0.0 -y 0.0 -z 0.5"/>
+  <arg name="init_pose"     default="-x 0.0 -y 0.0 -z 0.5 -Y 0.0"/>
   <arg name="namespace"     default="robot_1"/>
   <arg name="robot_type"    default="spirit"/>
 

--- a/quad_utils/src/math_utils.cpp
+++ b/quad_utils/src/math_utils.cpp
@@ -199,8 +199,23 @@ std::vector<double> unwrap(std::vector<double> data) {
 
   return data_unwrapped;
 }
+// VectorType unwrap(const VectorType& data) {
+//   VectorType data_unwrapped = data;
+//   for (int i = 1; i < data.size(); i++) {
+//     if (diff > M_PI) {
+//       for (int j = i; j < data.size(); j++) {
+//         data_unwrapped[j] = data_unwrapped[j] - 2 * M_PI;
+//       }
+//     } else if (diff < -M_PI) {
+//       for (int j = i; j < data.size(); j++) {
+//         data_unwrapped[j] = data_unwrapped[j] + 2 * M_PI;
+//       }
+//     }
+//   }
+//   return data_unwrapped;
+// }
 
-Eigen::MatrixXd sdlsInv(const Eigen::MatrixXd &jacobian) {
+Eigen::MatrixXd sdlsInv(const Eigen::MatrixXd& jacobian) {
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(
       jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
 


### PR DESCRIPTION
Hey,

I made some temporary fixes to the local planner. I unwrapped the reference NMPC and corresponding current state. Additionally, I made some modifications to the quad_gazebo.launch file s.t. I had some freedom of spawning robot_1 in any position and orientation.

There are some issues in the NMPC not being able to go past $-\pi$ for example, but in terms of local planner solving when yaw reference is $-\pi$, etc., those issues are mostly resolved. To see the resulting fixes, simply running

```
roslaunch quad_utils quad_gazebo.launch init_pose:="-x 6 -y -1 -z 0.5 -Y 3.2"
rostopic pub /robot_1/control/mode std_msgs/UInt8 "data: 1"
roslaunch quad_utils quad_plan.launch reference:=gbpl logging:=true
```

should let you see the results.

Let me know if there are any code style preferences that you would like to be changed.