### PR TITLE
Make utils functions input as const ref

### DIFF
--- a/quad_utils/include/quad_utils/math_utils.h
+++ b/quad_utils/include/quad_utils/math_utils.h
@@ -58,7 +58,7 @@ inline double wrapToPi(double val) {
  * @param[in] data data to wrap
  * @return Wrapped data
  */
-inline std::vector<double> wrapToPi(std::vector<double> data) {
+inline std::vector<double> wrapToPi(const std::vector<double> &data) {
   std::vector<double> data_wrapped = data;
   for (int i = 0; i < data.size(); i++) {
     data_wrapped[i] = wrapToPi(data[i]);
@@ -75,8 +75,8 @@ inline std::vector<double> wrapToPi(std::vector<double> data) {
  * @param[in] input_val Query point
  * @return Vector of interpolated values
  */
-std::vector<double> interpMat(const std::vector<double> input_vec,
-                              const std::vector<std::vector<double>> output_mat,
+std::vector<double> interpMat(const std::vector<double> &input_vec,
+                              const std::vector<std::vector<double>> &output_mat,
                               const double query_point);
 
 /**
@@ -88,8 +88,8 @@ std::vector<double> interpMat(const std::vector<double> input_vec,
  * @param[in] input_val Query point
  * @return Vector of interpolated values
  */
-Eigen::Vector3d interpVector3d(const std::vector<double> input_vec,
-                               const std::vector<Eigen::Vector3d> output_mat,
+Eigen::Vector3d interpVector3d(const std::vector<double> &input_vec,
+                               const std::vector<Eigen::Vector3d> &output_mat,
                                const double query_point);
 
 /**
@@ -102,8 +102,8 @@ Eigen::Vector3d interpVector3d(const std::vector<double> input_vec,
  * @return Vector of interpolated values
  */
 std::vector<Eigen::Vector3d> interpMatVector3d(
-    const std::vector<double> input_vec,
-    const std::vector<std::vector<Eigen::Vector3d>> output_mat,
+    const std::vector<double> &input_vec,
+    const std::vector<std::vector<Eigen::Vector3d>> &output_mat,
     const double query_point);
 
 /**
@@ -113,7 +113,7 @@ std::vector<Eigen::Vector3d> interpMatVector3d(
  * @param[in] input_val Query point
  * @return Correct output int corresponsing to the query point
  */
-int interpInt(const std::vector<double> input_vec, std::vector<int> output_vec,
+int interpInt(const std::vector<double> &input_vec, std::vector<int> &output_vec,
               const double query_point);
 
 /**
@@ -123,7 +123,7 @@ int interpInt(const std::vector<double> input_vec, std::vector<int> output_vec,
  * add one to maintain symmetry
  * @return Vector of filtered values
  */
-std::vector<double> movingAverageFilter(std::vector<double> data,
+std::vector<double> movingAverageFilter(const std::vector<double> &data,
                                         int window_size);
 
 /**
@@ -132,7 +132,7 @@ std::vector<double> movingAverageFilter(std::vector<double> data,
  * @param[in] dt The (constant) timestep between values in data.
  * @return Vector of differentiated signal
  */
-std::vector<double> centralDiff(std::vector<double> data, double dt);
+std::vector<double> centralDiff(const std::vector<double> &data, double dt);
 
 /**
  * @brief Unwrap a phase variable by filtering out differences > pi

--- a/quad_utils/include/quad_utils/math_utils.h
+++ b/quad_utils/include/quad_utils/math_utils.h
@@ -36,7 +36,7 @@ inline double lerp(double a, double b, double t) { return (a + t * (b - a)); }
  * @return Wrapped value
  */
 inline double wrapTo2Pi(double val) {
-  return fmod(2 * M_PI + fmod(val, 2 * M_PI), 2 * M_PI);
+    return fmod(2 * M_PI + fmod(val, 2 * M_PI), 2 * M_PI);
 }
 
 /**
@@ -45,12 +45,12 @@ inline double wrapTo2Pi(double val) {
  * @return Wrapped value
  */
 inline double wrapToPi(double val) {
-  return -M_PI + wrapTo2Pi(val + M_PI);
-  // double new_val = fmod(val + M_PI, 2*M_PI);
-  // while (new_val < 0) {
-  //   new_val += 2*M_PI;
-  // }
-  // return new_val-M_PI;
+    return -M_PI + wrapTo2Pi(val + M_PI);
+    // double new_val = fmod(val + M_PI, 2*M_PI);
+    // while (new_val < 0) {
+    //   new_val += 2*M_PI;
+    // }
+    // return new_val-M_PI;
 }
 
 /**
@@ -59,11 +59,11 @@ inline double wrapToPi(double val) {
  * @return Wrapped data
  */
 inline std::vector<double> wrapToPi(const std::vector<double> &data) {
-  std::vector<double> data_wrapped = data;
-  for (int i = 0; i < data.size(); i++) {
-    data_wrapped[i] = wrapToPi(data[i]);
-  }
-  return data_wrapped;
+    std::vector<double> data_wrapped = data;
+    for (int i = 0; i < data.size(); i++) {
+        data_wrapped[i] = wrapToPi(data[i]);
+    }
+    return data_wrapped;
 }
 
 /**
@@ -75,9 +75,10 @@ inline std::vector<double> wrapToPi(const std::vector<double> &data) {
  * @param[in] input_val Query point
  * @return Vector of interpolated values
  */
-std::vector<double> interpMat(const std::vector<double> &input_vec,
-                              const std::vector<std::vector<double>> &output_mat,
-                              const double query_point);
+std::vector<double> interpMat(
+    const std::vector<double> &input_vec,
+    const std::vector<std::vector<double>> &output_mat,
+    const double query_point);
 
 /**
  * @brief Interpolate data from column vectors contained in a matrix (vector of
@@ -113,8 +114,8 @@ std::vector<Eigen::Vector3d> interpMatVector3d(
  * @param[in] input_val Query point
  * @return Correct output int corresponsing to the query point
  */
-int interpInt(const std::vector<double> &input_vec, std::vector<int> &output_vec,
-              const double query_point);
+int interpInt(const std::vector<double> &input_vec,
+              std::vector<int> &output_vec, const double query_point);
 
 /**
  * @brief Filter a stl vector with a moving average window.

--- a/quad_utils/include/quad_utils/quad_kd.h
+++ b/quad_utils/include/quad_utils/quad_kd.h
@@ -27,435 +27,447 @@ namespace quad_utils {
 */
 class QuadKD {
  public:
-  /**
-   * @brief Constructor for QuadKD Class
-   * @return Constructed object of type QuadKD
-   */
-  QuadKD();
+    /**
+     * @brief Constructor for QuadKD Class
+     * @return Constructed object of type QuadKD
+     */
+    QuadKD();
 
-  /**
-   * @brief Constructor for QuadKD Class
-   * @param[in] ns Namespace
-   * @return Constructed object of type QuadKD
-   */
-  QuadKD(const std::string &ns);
+    /**
+     * @brief Constructor for QuadKD Class
+     * @param[in] ns Namespace
+     * @return Constructed object of type QuadKD
+     */
+    QuadKD(const std::string &ns);
 
-  /**
-   * @brief Initialize model for the class
-   * @param[in] ns Namespace
-   */
-  void initModel(const std::string &ns);
+    /**
+     * @brief Initialize model for the class
+     * @param[in] ns Namespace
+     */
+    void initModel(const std::string &ns);
 
-  /**
-   * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
-   * from a specified translation and a roll, pitch, and yaw vector
-   * @param[in] trans Translation from input frame to output frame
-   * @param[in] rpy Rotation from input frame to output frame as roll, pitch,
-   * yaw
-   * @return Homogenous transformation matrix
-   */
-  Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
-                                     const Eigen::Vector3d &rpy) const;
+    /**
+     * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
+     * from a specified translation and a roll, pitch, and yaw vector
+     * @param[in] trans Translation from input frame to output frame
+     * @param[in] rpy Rotation from input frame to output frame as roll, pitch,
+     * yaw
+     * @return Homogenous transformation matrix
+     */
+    Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
+                                       const Eigen::Vector3d &rpy) const;
 
-  /**
-   * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
-   * from a specified translation and an AngleAxis object
-   * @param[in] trans Translation from input frame to output frame
-   * @param[in] rot Rotation from input frame to output frame as AngleAxis
-   * @return Homogenous transformation matrix
-   */
-  Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
-                                     const Eigen::AngleAxisd &rot) const;
+    /**
+     * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
+     * from a specified translation and an AngleAxis object
+     * @param[in] trans Translation from input frame to output frame
+     * @param[in] rot Rotation from input frame to output frame as AngleAxis
+     * @return Homogenous transformation matrix
+     */
+    Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
+                                       const Eigen::AngleAxisd &rot) const;
 
-  /**
-   * @brief Transform a transformation matrix from the body frame to the world
-   * frame
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] transform_body Specified transform in the body frame
-   * @param[out] transform_world Specified transform in the world frame
-   */
-  void transformBodyToWorld(const Eigen::Vector3d &body_pos,
-                            const Eigen::Vector3d &body_rpy,
-                            const Eigen::Matrix4d &transform_body,
-                            Eigen::Matrix4d &transform_world) const;
+    /**
+     * @brief Transform a transformation matrix from the body frame to the world
+     * frame
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] transform_body Specified transform in the body frame
+     * @param[out] transform_world Specified transform in the world frame
+     */
+    void transformBodyToWorld(const Eigen::Vector3d &body_pos,
+                              const Eigen::Vector3d &body_rpy,
+                              const Eigen::Matrix4d &transform_body,
+                              Eigen::Matrix4d &transform_world) const;
 
-  /**
-   * @brief Transform a transformation matrix from the world frame to the body
-   * frame
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] transform_world Specified transform in the world frame
-   * @param[out] transform_body Specified transform in the body frame
-   */
-  void transformWorldToBody(const Eigen::Vector3d &body_pos,
-                            const Eigen::Vector3d &body_rpy,
-                            const Eigen::Matrix4d &transform_world,
-                            Eigen::Matrix4d &transform_body) const;
+    /**
+     * @brief Transform a transformation matrix from the world frame to the body
+     * frame
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] transform_world Specified transform in the world frame
+     * @param[out] transform_body Specified transform in the body frame
+     */
+    void transformWorldToBody(const Eigen::Vector3d &body_pos,
+                              const Eigen::Vector3d &body_rpy,
+                              const Eigen::Matrix4d &transform_world,
+                              Eigen::Matrix4d &transform_body) const;
 
-  /**
-   * @brief Compute forward kinematics for a specified leg from the body COM
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] g_body_foot Transform of the specified foot in world frame
-   */
-  void bodyToFootFKBodyFrame(int leg_index, const Eigen::Vector3d &joint_state,
-                             Eigen::Matrix4d &g_body_foot) const;
-
-  /**
-   * @brief Compute forward kinematics for a specified leg from the body COM
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] foot_pos_world Position of the specified foot in world frame
-   */
-  void bodyToFootFKBodyFrame(int leg_index, const Eigen::Vector3d &joint_state,
-                             Eigen::Vector3d &foot_pos_body) const;
-
-  /**
-   * @brief Compute forward kinematics for a specified leg
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] g_world_foot Transform of the specified foot in world frame
-   */
-  void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
-                               const Eigen::Vector3d &body_rpy,
+    /**
+     * @brief Compute forward kinematics for a specified leg from the body COM
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] g_body_foot Transform of the specified foot in world frame
+     */
+    void bodyToFootFKBodyFrame(int leg_index,
                                const Eigen::Vector3d &joint_state,
-                               Eigen::Matrix4d &g_world_foot) const;
+                               Eigen::Matrix4d &g_body_foot) const;
 
-  /**
-   * @brief Compute forward kinematics for a specified leg
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] foot_pos_world Position of the specified foot in world frame
-   */
-  void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
-                               const Eigen::Vector3d &body_rpy,
+    /**
+     * @brief Compute forward kinematics for a specified leg from the body COM
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] foot_pos_world Position of the specified foot in world frame
+     */
+    void bodyToFootFKBodyFrame(int leg_index,
                                const Eigen::Vector3d &joint_state,
-                               Eigen::Vector3d &foot_pos_world) const;
+                               Eigen::Vector3d &foot_pos_body) const;
 
-  /**
-   * @brief Compute forward kinematics for a specified leg
-   * @param[in] leg_index Spirit leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] g_world_knee Transform of the specified knee in world frame
-   */
-  void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
-                               const Eigen::Vector3d &body_rpy,
-                               const Eigen::Vector3d &joint_state,
-                               Eigen::Matrix4d &g_world_knee) const;
+    /**
+     * @brief Compute forward kinematics for a specified leg
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] g_world_foot Transform of the specified foot in world frame
+     */
+    void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                                 const Eigen::Vector3d &body_rpy,
+                                 const Eigen::Vector3d &joint_state,
+                                 Eigen::Matrix4d &g_world_foot) const;
 
-  /**
-   * @brief Compute forward kinematics for a specified leg
-   * @param[in] leg_index Spirit leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
-   * @param[out] knee_pos_world Position of the specified knee in world frame
-   */
-  void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
-                               const Eigen::Vector3d &body_rpy,
-                               const Eigen::Vector3d &joint_state,
-                               Eigen::Vector3d &knee_pos_world) const;
+    /**
+     * @brief Compute forward kinematics for a specified leg
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] foot_pos_world Position of the specified foot in world frame
+     */
+    void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                                 const Eigen::Vector3d &body_rpy,
+                                 const Eigen::Vector3d &joint_state,
+                                 Eigen::Vector3d &foot_pos_world) const;
 
-  /**
-   * @brief Compute inverse kinematics for a specified leg
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[in] foot_pos_world Position of the specified foot in world frame
-   * @param[out] joint_state Joint states for the specified leg (abad, hip,
-   * knee)
-   */
-  bool worldToFootIKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
-                               const Eigen::Vector3d &body_rpy,
-                               const Eigen::Vector3d &foot_pos_world,
-                               Eigen::Vector3d &joint_state) const;
+    /**
+     * @brief Compute forward kinematics for a specified leg
+     * @param[in] leg_index Spirit leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] g_world_knee Transform of the specified knee in world frame
+     */
+    void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                                 const Eigen::Vector3d &body_rpy,
+                                 const Eigen::Vector3d &joint_state,
+                                 Eigen::Matrix4d &g_world_knee) const;
 
-  /**
-   * @brief Compute inverse kinematics for a specified leg in the leg base frame
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] foot_pos_legbase Position of the specified foot in leg base
-   * frame
-   * @param[out] joint_state Joint states for the specified leg (abad, hip,
-   * knee)
-   */
-  bool legbaseToFootIKLegbaseFrame(int leg_index,
-                                   const Eigen::Vector3d &foot_pos_legbase,
-                                   Eigen::Vector3d &joint_state) const;
+    /**
+     * @brief Compute forward kinematics for a specified leg
+     * @param[in] leg_index Spirit leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     * @param[out] knee_pos_world Position of the specified knee in world frame
+     */
+    void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                                 const Eigen::Vector3d &body_rpy,
+                                 const Eigen::Vector3d &joint_state,
+                                 Eigen::Vector3d &knee_pos_world) const;
 
-  /**
-   * @brief Get the lower joint limit of a particular joint
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] joint_index Index for joint (0 = abad, 1 = hip, 2 = knee)
-   * @return Requested joint limit
-   */
-  double getJointLowerLimit(int leg_index, int joint_index) const;
+    /**
+     * @brief Compute inverse kinematics for a specified leg
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[in] foot_pos_world Position of the specified foot in world frame
+     * @param[out] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     */
+    bool worldToFootIKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                                 const Eigen::Vector3d &body_rpy,
+                                 const Eigen::Vector3d &foot_pos_world,
+                                 Eigen::Vector3d &joint_state) const;
 
-  /**
-   * @brief Get the upper joint limit of a particular joint
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] joint_index Index for joint (0 = abad, 1 = hip, 2 = knee)
-   * @return Requested joint limit
-   */
-  double getJointUpperLimit(int leg_index, int joint_index) const;
+    /**
+     * @brief Compute inverse kinematics for a specified leg in the leg base
+     * frame
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] foot_pos_legbase Position of the specified foot in leg base
+     * frame
+     * @param[out] joint_state Joint states for the specified leg (abad, hip,
+     * knee)
+     */
+    bool legbaseToFootIKLegbaseFrame(int leg_index,
+                                     const Eigen::Vector3d &foot_pos_legbase,
+                                     Eigen::Vector3d &joint_state) const;
 
-  /**
-   * @brief Get the upper joint limit of a particular joint
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] link_index Index for link (0 = abad, 1 = upper, 2 = lower)
-   * @return Requested link length
-   */
-  double getLinkLength(int leg_index, int link_index) const;
+    /**
+     * @brief Get the lower joint limit of a particular joint
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] joint_index Index for joint (0 = abad, 1 = hip, 2 = knee)
+     * @return Requested joint limit
+     */
+    double getJointLowerLimit(int leg_index, int joint_index) const;
 
-  /**
-   * @brief Get the transform from the world frame to the leg base
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[out] g_world_legbase Transformation matrix of world to leg base
-   */
-  void worldToLegbaseFKWorldFrame(int leg_index,
-                                  const Eigen::Vector3d &body_pos,
-                                  const Eigen::Vector3d &body_rpy,
-                                  Eigen::Matrix4d &g_world_legbase) const;
+    /**
+     * @brief Get the upper joint limit of a particular joint
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] joint_index Index for joint (0 = abad, 1 = hip, 2 = knee)
+     * @return Requested joint limit
+     */
+    double getJointUpperLimit(int leg_index, int joint_index) const;
 
-  /**
-   * @brief Get the position of the leg base frame origin in the world frame
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[out] leg_base_pos_world Origin of leg base frame in world frame
-   */
-  void worldToLegbaseFKWorldFrame(int leg_index,
-                                  const Eigen::Vector3d &body_pos,
-                                  const Eigen::Vector3d &body_rpy,
-                                  Eigen::Vector3d &leg_base_pos_world) const;
+    /**
+     * @brief Get the upper joint limit of a particular joint
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] link_index Index for link (0 = abad, 1 = upper, 2 = lower)
+     * @return Requested link length
+     */
+    double getLinkLength(int leg_index, int link_index) const;
 
-  /**
-   * @brief Get the position of the nominal hip location in the world frame
-   * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
-   * @param[in] body_pos Position of center of body frame
-   * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
-   * @param[out] nominal_hip_pos_world Location of nominal hip in world frame
-   */
-  void worldToNominalHipFKWorldFrame(int leg_index,
-                                     const Eigen::Vector3d &body_pos,
-                                     const Eigen::Vector3d &body_rpy,
-                                     Eigen::Vector3d &nominal_hip_pos_world) const;
+    /**
+     * @brief Get the transform from the world frame to the leg base
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[out] g_world_legbase Transformation matrix of world to leg base
+     */
+    void worldToLegbaseFKWorldFrame(int leg_index,
+                                    const Eigen::Vector3d &body_pos,
+                                    const Eigen::Vector3d &body_rpy,
+                                    Eigen::Matrix4d &g_world_legbase) const;
 
-  /**
-   * @brief Compute Jacobian for generalized coordinates
-   * @param[in] state Joint and body states
-   * @param[out] jacobian Jacobian for generalized coordinates
-   */
-  void getJacobianGenCoord(const Eigen::VectorXd &state,
-                           Eigen::MatrixXd &jacobian) const;
+    /**
+     * @brief Get the position of the leg base frame origin in the world frame
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[out] leg_base_pos_world Origin of leg base frame in world frame
+     */
+    void worldToLegbaseFKWorldFrame(int leg_index,
+                                    const Eigen::Vector3d &body_pos,
+                                    const Eigen::Vector3d &body_rpy,
+                                    Eigen::Vector3d &leg_base_pos_world) const;
 
-  /**
-   * @brief Compute Jacobian for angular velocity in body frame
-   * @param[in] state Joint and body states
-   * @param[out] jacobian Jacobian for angular velocity in body frame
-   */
-  void getJacobianBodyAngVel(const Eigen::VectorXd &state,
+    /**
+     * @brief Get the position of the nominal hip location in the world frame
+     * @param[in] leg_index Quad leg (0 = FL, 1 = BL, 2 = FR, 3 = BR)
+     * @param[in] body_pos Position of center of body frame
+     * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
+     * @param[out] nominal_hip_pos_world Location of nominal hip in world frame
+     */
+    void worldToNominalHipFKWorldFrame(
+        int leg_index, const Eigen::Vector3d &body_pos,
+        const Eigen::Vector3d &body_rpy,
+        Eigen::Vector3d &nominal_hip_pos_world) const;
+
+    /**
+     * @brief Compute Jacobian for generalized coordinates
+     * @param[in] state Joint and body states
+     * @param[out] jacobian Jacobian for generalized coordinates
+     */
+    void getJacobianGenCoord(const Eigen::VectorXd &state,
                              Eigen::MatrixXd &jacobian) const;
 
-  /**
-   * @brief Compute Jacobian for angular velocity in world frame
-   * @param[in] state Joint and body states
-   * @param[out] jacobian Jacobian for angular velocity in world frame
-   */
-  void getJacobianWorldAngVel(const Eigen::VectorXd &state,
-                              Eigen::MatrixXd &jacobian) const;
+    /**
+     * @brief Compute Jacobian for angular velocity in body frame
+     * @param[in] state Joint and body states
+     * @param[out] jacobian Jacobian for angular velocity in body frame
+     */
+    void getJacobianBodyAngVel(const Eigen::VectorXd &state,
+                               Eigen::MatrixXd &jacobian) const;
 
-  /**
-   * @brief Compute rotation matrix given roll pitch and yaw
-   * @param[in] rpy Roll pitch and yaw
-   * @param[out] rot Rotation matrix
-   */
-  void getRotationMatrix(const Eigen::VectorXd &rpy,
-                         Eigen::Matrix3d &rot) const;
+    /**
+     * @brief Compute Jacobian for angular velocity in world frame
+     * @param[in] state Joint and body states
+     * @param[out] jacobian Jacobian for angular velocity in world frame
+     */
+    void getJacobianWorldAngVel(const Eigen::VectorXd &state,
+                                Eigen::MatrixXd &jacobian) const;
 
-  /**
-   * @brief Compute inverse dynamics for swing leg
-   * @param[in] state_pos Position states
-   * @param[in] state_vel Velocity states
-   * @param[in] foot_acc Foot absolute acceleration in world frame
-   * @param[in] grf Ground reaction force
-   * @param[in] contact_mode Contact mode of the legs
-   * @param[out] tau Joint torques
-   */
-  void computeInverseDynamics(const Eigen::VectorXd &state_pos,
-                              const Eigen::VectorXd &state_vel,
-                              const Eigen::VectorXd &foot_acc,
-                              const Eigen::VectorXd &grf,
-                              const std::vector<int> &contact_mode,
-                              Eigen::VectorXd &tau) const;
+    /**
+     * @brief Compute rotation matrix given roll pitch and yaw
+     * @param[in] rpy Roll pitch and yaw
+     * @param[out] rot Rotation matrix
+     */
+    void getRotationMatrix(const Eigen::VectorXd &rpy,
+                           Eigen::Matrix3d &rot) const;
 
-  /**
-   * @brief Convert centroidal model states (foot coordinates and grfs) to full
-   * body (joints and torques)
-   * @param[in] body_state Position states
-   * @param[in] foot_positions Foot positions in the world frame
-   * @param[in] foot_velocities Foot velocities in the world frame
-   * @param[in] grfs Ground reaction forces
-   * @param[out] joint_positions Joint positions
-   * @param[out] joint_velocities Joint velocities
-   * @param[out] tau Joint torques
-   * @return boolean for exactness of kinematics
-   */
-  bool convertCentroidalToFullBody(const Eigen::VectorXd &body_state,
-                                   const Eigen::VectorXd &foot_positions,
-                                   const Eigen::VectorXd &foot_velocities,
-                                   const Eigen::VectorXd &grfs,
-                                   Eigen::VectorXd &joint_positions,
-                                   Eigen::VectorXd &joint_velocities,
-                                   Eigen::VectorXd &torques);
+    /**
+     * @brief Compute inverse dynamics for swing leg
+     * @param[in] state_pos Position states
+     * @param[in] state_vel Velocity states
+     * @param[in] foot_acc Foot absolute acceleration in world frame
+     * @param[in] grf Ground reaction force
+     * @param[in] contact_mode Contact mode of the legs
+     * @param[out] tau Joint torques
+     */
+    void computeInverseDynamics(const Eigen::VectorXd &state_pos,
+                                const Eigen::VectorXd &state_vel,
+                                const Eigen::VectorXd &foot_acc,
+                                const Eigen::VectorXd &grf,
+                                const std::vector<int> &contact_mode,
+                                Eigen::VectorXd &tau) const;
 
-  /**
-   * @brief Apply a uniform maximum torque to a given set of joint torques
-   * @param[in] torques Joint torques. in Nm
-   * @param[in] constrained_torques Joint torques after applying max, in Nm
-   * @return Boolean to indicate if initial torques is feasible (checks if
-   * torques == constrained_torques)
-   */
-  bool applyMotorModel(const Eigen::VectorXd &torques,
-                       Eigen::VectorXd &constrained_torques);
+    /**
+     * @brief Convert centroidal model states (foot coordinates and grfs) to
+     * full body (joints and torques)
+     * @param[in] body_state Position states
+     * @param[in] foot_positions Foot positions in the world frame
+     * @param[in] foot_velocities Foot velocities in the world frame
+     * @param[in] grfs Ground reaction forces
+     * @param[out] joint_positions Joint positions
+     * @param[out] joint_velocities Joint velocities
+     * @param[out] tau Joint torques
+     * @return boolean for exactness of kinematics
+     */
+    bool convertCentroidalToFullBody(const Eigen::VectorXd &body_state,
+                                     const Eigen::VectorXd &foot_positions,
+                                     const Eigen::VectorXd &foot_velocities,
+                                     const Eigen::VectorXd &grfs,
+                                     Eigen::VectorXd &joint_positions,
+                                     Eigen::VectorXd &joint_velocities,
+                                     Eigen::VectorXd &torques);
 
-  /**
-   * @brief Apply a linear motor model to a given set of joint torques and
-   * velocities
-   * @param[in] torques Joint torques. in Nm
-   * @param[in] joint_velocities Velocities of each joint. in rad/s
-   * @param[in] constrained_torques Joint torques after applying motor model, in
-   * Nm
-   * @return Boolean to indicate if initial torques is feasible (checks if
-   * torques == constrained_torques)
-   */
-  bool applyMotorModel(const Eigen::VectorXd &torques,
-                       const Eigen::VectorXd &joint_velocities,
-                       Eigen::VectorXd &constrained_torques);
+    /**
+     * @brief Apply a uniform maximum torque to a given set of joint torques
+     * @param[in] torques Joint torques. in Nm
+     * @param[in] constrained_torques Joint torques after applying max, in Nm
+     * @return Boolean to indicate if initial torques is feasible (checks if
+     * torques == constrained_torques)
+     */
+    bool applyMotorModel(const Eigen::VectorXd &torques,
+                         Eigen::VectorXd &constrained_torques);
 
-  /**
-   * @brief Check if state is valid
-   * @param[in] body_state Robot body positions and velocities
-   * @param[in] joint_state Joint positions and velocities
-   * @param[in] torques Joint torques
-   * @param[in] terrain Map of the terrain for collision checking
-   * @return Boolean for state validity
-   */
-  bool isValidFullState(const Eigen::VectorXd &body_state,
-                        const Eigen::VectorXd &joint_state,
-                        const Eigen::VectorXd &torques,
-                        const grid_map::GridMap &terrain,
-                        Eigen::VectorXd &state_violation,
-                        Eigen::VectorXd &control_violation);
+    /**
+     * @brief Apply a linear motor model to a given set of joint torques and
+     * velocities
+     * @param[in] torques Joint torques. in Nm
+     * @param[in] joint_velocities Velocities of each joint. in rad/s
+     * @param[in] constrained_torques Joint torques after applying motor model,
+     * in Nm
+     * @return Boolean to indicate if initial torques is feasible (checks if
+     * torques == constrained_torques)
+     */
+    bool applyMotorModel(const Eigen::VectorXd &torques,
+                         const Eigen::VectorXd &joint_velocities,
+                         Eigen::VectorXd &constrained_torques);
 
-  /**
-   * @brief Check if state is valid
-   * @param[in] body_state Robot body positions and velocities
-   * @param[in] foot_positions Foot positions
-   * @param[in] foot_velocities Foot velocities
-   * @param[in] grfs Ground reaction forces in the world frame
-   * @param[in] terrain Map of the terrain for collision checking
-   * @return Boolean for state validity
-   */
-  bool isValidCentroidalState(
-      const Eigen::VectorXd &body_state, const Eigen::VectorXd &foot_positions,
-      const Eigen::VectorXd &foot_velocities, const Eigen::VectorXd &grfs,
-      const grid_map::GridMap &terrain, Eigen::VectorXd &joint_positions,
-      Eigen::VectorXd &joint_velocities, Eigen::VectorXd &torques,
-      Eigen::VectorXd &state_violation, Eigen::VectorXd &control_violation);
+    /**
+     * @brief Check if state is valid
+     * @param[in] body_state Robot body positions and velocities
+     * @param[in] joint_state Joint positions and velocities
+     * @param[in] torques Joint torques
+     * @param[in] terrain Map of the terrain for collision checking
+     * @return Boolean for state validity
+     */
+    bool isValidFullState(const Eigen::VectorXd &body_state,
+                          const Eigen::VectorXd &joint_state,
+                          const Eigen::VectorXd &torques,
+                          const grid_map::GridMap &terrain,
+                          Eigen::VectorXd &state_violation,
+                          Eigen::VectorXd &control_violation);
 
-  inline double getGroundClearance(const Eigen::Vector3d &point,
-                                   const grid_map::GridMap &terrain) {
-    grid_map::Position pos = {point.x(), point.y()};
-    return (point.z() - terrain.atPosition("z", pos));
-  }
+    /**
+     * @brief Check if state is valid
+     * @param[in] body_state Robot body positions and velocities
+     * @param[in] foot_positions Foot positions
+     * @param[in] foot_velocities Foot velocities
+     * @param[in] grfs Ground reaction forces in the world frame
+     * @param[in] terrain Map of the terrain for collision checking
+     * @return Boolean for state validity
+     */
+    bool isValidCentroidalState(
+        const Eigen::VectorXd &body_state,
+        const Eigen::VectorXd &foot_positions,
+        const Eigen::VectorXd &foot_velocities, const Eigen::VectorXd &grfs,
+        const grid_map::GridMap &terrain, Eigen::VectorXd &joint_positions,
+        Eigen::VectorXd &joint_velocities, Eigen::VectorXd &torques,
+        Eigen::VectorXd &state_violation, Eigen::VectorXd &control_violation);
+
+    inline double getGroundClearance(const Eigen::Vector3d &point,
+                                     const grid_map::GridMap &terrain) {
+        grid_map::Position pos = {point.x(), point.y()};
+        return (point.z() - terrain.atPosition("z", pos));
+    }
 
  private:
-  /// Number of feet
-  const int num_feet_ = 4;
+    /// Number of feet
+    const int num_feet_ = 4;
 
-  /// Vector of the abad link lengths
-  std::vector<double> l0_vec_;
+    /// Vector of the abad link lengths
+    std::vector<double> l0_vec_;
 
-  /// Upper link length
-  double l1_;
+    /// Upper link length
+    double l1_;
 
-  /// Lower link length
-  double l2_;
+    /// Lower link length
+    double l2_;
 
-  /// Abad offset from legbase
-  Eigen::Vector3d abad_offset_;
+    /// Abad offset from legbase
+    Eigen::Vector3d abad_offset_;
 
-  /// Knee offset from hip
-  Eigen::Vector3d knee_offset_;
+    /// Knee offset from hip
+    Eigen::Vector3d knee_offset_;
 
-  /// Foot offset from knee
-  Eigen::Vector3d foot_offset_;
+    /// Foot offset from knee
+    Eigen::Vector3d foot_offset_;
 
-  /// Vector of legbase offsets
-  std::vector<Eigen::Vector3d> legbase_offsets_;
+    /// Vector of legbase offsets
+    std::vector<Eigen::Vector3d> legbase_offsets_;
 
-  /// Vector of legbase offsets
-  std::vector<Eigen::Matrix4d> g_body_legbases_;
+    /// Vector of legbase offsets
+    std::vector<Eigen::Matrix4d> g_body_legbases_;
 
-  /// Epsilon offset for joint bounds
-  const double joint_eps = 0.1;
+    /// Epsilon offset for joint bounds
+    const double joint_eps = 0.1;
 
-  /// Vector of the joint lower limits
-  std::vector<std::vector<double>> joint_min_;
+    /// Vector of the joint lower limits
+    std::vector<std::vector<double>> joint_min_;
 
-  /// Vector of the joint upper limits
-  std::vector<std::vector<double>> joint_max_;
+    /// Vector of the joint upper limits
+    std::vector<std::vector<double>> joint_max_;
 
-  RigidBodyDynamics::Model *model_;
+    RigidBodyDynamics::Model *model_;
 
-  std::vector<std::string> body_name_list_;
+    std::vector<std::string> body_name_list_;
 
-  std::vector<unsigned int> body_id_list_;
+    std::vector<unsigned int> body_id_list_;
 
-  std::vector<int> leg_idx_list_;
+    std::vector<int> leg_idx_list_;
 
-  /// Abad max joint torque
-  const double abad_tau_max_ = 21;
+    /// Abad max joint torque
+    const double abad_tau_max_ = 21;
 
-  /// Hip max joint torque
-  const double hip_tau_max_ = 21;
+    /// Hip max joint torque
+    const double hip_tau_max_ = 21;
 
-  /// Knee max joint torque
-  const double knee_tau_max_ = 32;
+    /// Knee max joint torque
+    const double knee_tau_max_ = 32;
 
-  /// Vector of max torques
-  const Eigen::VectorXd tau_max_ =
-      (Eigen::VectorXd(12) << abad_tau_max_, hip_tau_max_, knee_tau_max_,
-       abad_tau_max_, hip_tau_max_, knee_tau_max_, abad_tau_max_, hip_tau_max_,
-       knee_tau_max_, abad_tau_max_, hip_tau_max_, knee_tau_max_)
-          .finished();
+    /// Vector of max torques
+    const Eigen::VectorXd tau_max_ =
+        (Eigen::VectorXd(12) << abad_tau_max_, hip_tau_max_, knee_tau_max_,
+         abad_tau_max_, hip_tau_max_, knee_tau_max_, abad_tau_max_,
+         hip_tau_max_, knee_tau_max_, abad_tau_max_, hip_tau_max_,
+         knee_tau_max_)
+            .finished();
 
-  /// Abad max joint velocity
-  const double abad_vel_max_ = 37.7;
+    /// Abad max joint velocity
+    const double abad_vel_max_ = 37.7;
 
-  /// Hip max joint velocity
-  const double hip_vel_max_ = 37.7;
+    /// Hip max joint velocity
+    const double hip_vel_max_ = 37.7;
 
-  /// Knee max joint velocity
-  const double knee_vel_max_ = 25.1;
+    /// Knee max joint velocity
+    const double knee_vel_max_ = 25.1;
 
-  /// Vector of max velocities
-  const Eigen::VectorXd vel_max_ =
-      (Eigen::VectorXd(12) << abad_vel_max_, hip_vel_max_, knee_vel_max_,
-       abad_vel_max_, hip_vel_max_, knee_vel_max_, abad_vel_max_, hip_vel_max_,
-       knee_vel_max_, abad_vel_max_, hip_vel_max_, knee_vel_max_)
-          .finished();
+    /// Vector of max velocities
+    const Eigen::VectorXd vel_max_ =
+        (Eigen::VectorXd(12) << abad_vel_max_, hip_vel_max_, knee_vel_max_,
+         abad_vel_max_, hip_vel_max_, knee_vel_max_, abad_vel_max_,
+         hip_vel_max_, knee_vel_max_, abad_vel_max_, hip_vel_max_,
+         knee_vel_max_)
+            .finished();
 
-  const Eigen::VectorXd mm_slope_ = tau_max_.cwiseQuotient(vel_max_);
+    const Eigen::VectorXd mm_slope_ = tau_max_.cwiseQuotient(vel_max_);
 };
 
 }  // namespace quad_utils

--- a/quad_utils/include/quad_utils/quad_kd.h
+++ b/quad_utils/include/quad_utils/quad_kd.h
@@ -38,13 +38,13 @@ class QuadKD {
    * @param[in] ns Namespace
    * @return Constructed object of type QuadKD
    */
-  QuadKD(std::string ns);
+  QuadKD(const std::string &ns);
 
   /**
    * @brief Initialize model for the class
    * @param[in] ns Namespace
    */
-  void initModel(std::string ns);
+  void initModel(const std::string &ns);
 
   /**
    * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
@@ -54,8 +54,8 @@ class QuadKD {
    * yaw
    * @return Homogenous transformation matrix
    */
-  Eigen::Matrix4d createAffineMatrix(Eigen::Vector3d trans,
-                                     Eigen::Vector3d rpy) const;
+  Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
+                                     const Eigen::Vector3d &rpy) const;
 
   /**
    * @brief Create an Eigen Eigen::Matrix4d containing a homogeneous transform
@@ -64,8 +64,8 @@ class QuadKD {
    * @param[in] rot Rotation from input frame to output frame as AngleAxis
    * @return Homogenous transformation matrix
    */
-  Eigen::Matrix4d createAffineMatrix(Eigen::Vector3d trans,
-                                     Eigen::AngleAxisd rot) const;
+  Eigen::Matrix4d createAffineMatrix(const Eigen::Vector3d &trans,
+                                     const Eigen::AngleAxisd &rot) const;
 
   /**
    * @brief Transform a transformation matrix from the body frame to the world
@@ -75,8 +75,9 @@ class QuadKD {
    * @param[in] transform_body Specified transform in the body frame
    * @param[out] transform_world Specified transform in the world frame
    */
-  void transformBodyToWorld(Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
-                            Eigen::Matrix4d transform_body,
+  void transformBodyToWorld(const Eigen::Vector3d &body_pos,
+                            const Eigen::Vector3d &body_rpy,
+                            const Eigen::Matrix4d &transform_body,
                             Eigen::Matrix4d &transform_world) const;
 
   /**
@@ -87,8 +88,9 @@ class QuadKD {
    * @param[in] transform_world Specified transform in the world frame
    * @param[out] transform_body Specified transform in the body frame
    */
-  void transformWorldToBody(Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
-                            Eigen::Matrix4d transform_world,
+  void transformWorldToBody(const Eigen::Vector3d &body_pos,
+                            const Eigen::Vector3d &body_rpy,
+                            const Eigen::Matrix4d &transform_world,
                             Eigen::Matrix4d &transform_body) const;
 
   /**
@@ -97,7 +99,7 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] g_body_foot Transform of the specified foot in world frame
    */
-  void bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
+  void bodyToFootFKBodyFrame(int leg_index, const Eigen::Vector3d &joint_state,
                              Eigen::Matrix4d &g_body_foot) const;
 
   /**
@@ -106,7 +108,7 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] foot_pos_world Position of the specified foot in world frame
    */
-  void bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
+  void bodyToFootFKBodyFrame(int leg_index, const Eigen::Vector3d &joint_state,
                              Eigen::Vector3d &foot_pos_body) const;
 
   /**
@@ -117,9 +119,9 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] g_world_foot Transform of the specified foot in world frame
    */
-  void worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                               Eigen::Vector3d body_rpy,
-                               Eigen::Vector3d joint_state,
+  void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                               const Eigen::Vector3d &body_rpy,
+                               const Eigen::Vector3d &joint_state,
                                Eigen::Matrix4d &g_world_foot) const;
 
   /**
@@ -130,9 +132,9 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] foot_pos_world Position of the specified foot in world frame
    */
-  void worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                               Eigen::Vector3d body_rpy,
-                               Eigen::Vector3d joint_state,
+  void worldToFootFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                               const Eigen::Vector3d &body_rpy,
+                               const Eigen::Vector3d &joint_state,
                                Eigen::Vector3d &foot_pos_world) const;
 
   /**
@@ -143,9 +145,9 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] g_world_knee Transform of the specified knee in world frame
    */
-  void worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                               Eigen::Vector3d body_rpy,
-                               Eigen::Vector3d joint_state,
+  void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                               const Eigen::Vector3d &body_rpy,
+                               const Eigen::Vector3d &joint_state,
                                Eigen::Matrix4d &g_world_knee) const;
 
   /**
@@ -156,9 +158,9 @@ class QuadKD {
    * @param[in] joint_state Joint states for the specified leg (abad, hip, knee)
    * @param[out] knee_pos_world Position of the specified knee in world frame
    */
-  void worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                               Eigen::Vector3d body_rpy,
-                               Eigen::Vector3d joint_state,
+  void worldToKneeFKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                               const Eigen::Vector3d &body_rpy,
+                               const Eigen::Vector3d &joint_state,
                                Eigen::Vector3d &knee_pos_world) const;
 
   /**
@@ -170,9 +172,9 @@ class QuadKD {
    * @param[out] joint_state Joint states for the specified leg (abad, hip,
    * knee)
    */
-  bool worldToFootIKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                               Eigen::Vector3d body_rpy,
-                               Eigen::Vector3d foot_pos_world,
+  bool worldToFootIKWorldFrame(int leg_index, const Eigen::Vector3d &body_pos,
+                               const Eigen::Vector3d &body_rpy,
+                               const Eigen::Vector3d &foot_pos_world,
                                Eigen::Vector3d &joint_state) const;
 
   /**
@@ -184,7 +186,7 @@ class QuadKD {
    * knee)
    */
   bool legbaseToFootIKLegbaseFrame(int leg_index,
-                                   Eigen::Vector3d foot_pos_legbase,
+                                   const Eigen::Vector3d &foot_pos_legbase,
                                    Eigen::Vector3d &joint_state) const;
 
   /**
@@ -218,8 +220,9 @@ class QuadKD {
    * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
    * @param[out] g_world_legbase Transformation matrix of world to leg base
    */
-  void worldToLegbaseFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                  Eigen::Vector3d body_rpy,
+  void worldToLegbaseFKWorldFrame(int leg_index,
+                                  const Eigen::Vector3d &body_pos,
+                                  const Eigen::Vector3d &body_rpy,
                                   Eigen::Matrix4d &g_world_legbase) const;
 
   /**
@@ -229,8 +232,9 @@ class QuadKD {
    * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
    * @param[out] leg_base_pos_world Origin of leg base frame in world frame
    */
-  void worldToLegbaseFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                  Eigen::Vector3d body_rpy,
+  void worldToLegbaseFKWorldFrame(int leg_index,
+                                  const Eigen::Vector3d &body_pos,
+                                  const Eigen::Vector3d &body_rpy,
                                   Eigen::Vector3d &leg_base_pos_world) const;
 
   /**
@@ -240,9 +244,10 @@ class QuadKD {
    * @param[in] body_rpy Orientation of body frame in roll, pitch, yaw
    * @param[out] nominal_hip_pos_world Location of nominal hip in world frame
    */
-  void worldToNominalHipFKWorldFrame(
-      int leg_index, Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
-      Eigen::Vector3d &nominal_hip_pos_world) const;
+  void worldToNominalHipFKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     Eigen::Vector3d &nominal_hip_pos_world) const;
 
   /**
    * @brief Compute Jacobian for generalized coordinates

--- a/quad_utils/include/quad_utils/ros_utils.h
+++ b/quad_utils/include/quad_utils/ros_utils.h
@@ -16,7 +16,7 @@ namespace quad_utils {
  */
 inline double getROSMessageAgeInMs(const std_msgs::Header &header,
                                    const ros::Time &t_compare) {
-  return (t_compare - header.stamp).toSec() * 1000.0;
+    return (t_compare - header.stamp).toSec() * 1000.0;
 }
 
 /**
@@ -25,8 +25,8 @@ inline double getROSMessageAgeInMs(const std_msgs::Header &header,
  * @return Age in ms (compared to ros::Time::now())
  */
 inline double getROSMessageAgeInMs(const std_msgs::Header &header) {
-  ros::Time t_compare = ros::Time::now();
-  return quad_utils::getROSMessageAgeInMs(header, t_compare);
+    ros::Time t_compare = ros::Time::now();
+    return quad_utils::getROSMessageAgeInMs(header, t_compare);
 }
 
 /**
@@ -35,7 +35,7 @@ inline double getROSMessageAgeInMs(const std_msgs::Header &header) {
  * @return Time in plan (compared to ros::Time::now())
  */
 inline double getDurationSinceTime(const ros::Time &plan_start) {
-  return (ros::Time::now() - plan_start).toSec();
+    return (ros::Time::now() - plan_start).toSec();
 }
 
 /**
@@ -48,9 +48,9 @@ inline double getDurationSinceTime(const ros::Time &plan_start) {
  */
 inline void getPlanIndex(const ros::Time &plan_start, double dt, int &index,
                          double &first_element_duration) {
-  double duration = getDurationSinceTime(plan_start);
-  index = std::floor(duration / dt);
-  first_element_duration = (index + 1) * dt - duration;
+    double duration = getDurationSinceTime(plan_start);
+    index = std::floor(duration / dt);
+    first_element_duration = (index + 1) * dt - duration;
 }
 
 /**
@@ -63,11 +63,12 @@ inline void getPlanIndex(const ros::Time &plan_start, double dt, int &index,
 template <class ParamType>
 inline bool loadROSParam(ros::NodeHandle nh, const std::string &paramName,
                          ParamType &varName) {
-  if (!nh.getParam(paramName, varName)) {
-    ROS_ERROR("Can't find param %s from parameter server", paramName.c_str());
-    return false;
-  }
-  return true;
+    if (!nh.getParam(paramName, varName)) {
+        ROS_ERROR("Can't find param %s from parameter server",
+                  paramName.c_str());
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -80,15 +81,18 @@ inline bool loadROSParam(ros::NodeHandle nh, const std::string &paramName,
  * @return boolean (true if found rosparam, false if loaded default)
  */
 template <class ParamType>
-inline bool loadROSParamDefault(ros::NodeHandle nh, const std::string &paramName,
-                                ParamType &varName, const ParamType &defaultVal) {
-  if (!nh.getParam(paramName, varName)) {
-    varName = defaultVal;
-    ROS_INFO("Can't find param %s on rosparam server, loading default value.",
-             paramName.c_str());
-    return false;
-  }
-  return true;
+inline bool loadROSParamDefault(ros::NodeHandle nh,
+                                const std::string &paramName,
+                                ParamType &varName,
+                                const ParamType &defaultVal) {
+    if (!nh.getParam(paramName, varName)) {
+        varName = defaultVal;
+        ROS_INFO(
+            "Can't find param %s on rosparam server, loading default value.",
+            paramName.c_str());
+        return false;
+    }
+    return true;
 }
 
 // /**
@@ -117,8 +121,9 @@ void updateStateHeaders(quad_msgs::RobotState &msg, const ros::Time &stamp,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated header
  */
-void interpHeader(const std_msgs::Header &header_1, const std_msgs::Header &header_2,
-                  double t_interp, std_msgs::Header &interp_header);
+void interpHeader(const std_msgs::Header &header_1,
+                  const std_msgs::Header &header_2, double t_interp,
+                  std_msgs::Header &interp_header);
 
 /**
  * @brief Interpolate data between two Odometry messages.
@@ -127,8 +132,9 @@ void interpHeader(const std_msgs::Header &header_1, const std_msgs::Header &head
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated Odometry message
  */
-void interpOdometry(const quad_msgs::BodyState &state_1, const quad_msgs::BodyState &state_2,
-                    double t_interp, quad_msgs::BodyState &interp_state);
+void interpOdometry(const quad_msgs::BodyState &state_1,
+                    const quad_msgs::BodyState &state_2, double t_interp,
+                    quad_msgs::BodyState &interp_state);
 
 /**
  * @brief Interpolate data between two JointState messages.
@@ -149,7 +155,8 @@ void interpJointState(const sensor_msgs::JointState &state_1,
  * @param[out] interp_state Interpolated FootState message
  */
 void interpMultiFootState(const quad_msgs::MultiFootState &state_1,
-                          const quad_msgs::MultiFootState &state_2, double t_interp,
+                          const quad_msgs::MultiFootState &state_2,
+                          double t_interp,
                           quad_msgs::MultiFootState &interp_state);
 
 /**
@@ -159,8 +166,9 @@ void interpMultiFootState(const quad_msgs::MultiFootState &state_1,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated GRFArray message
  */
-void interpGRFArray(const quad_msgs::GRFArray &state_1, const quad_msgs::GRFArray &state_2,
-                    double t_interp, quad_msgs::GRFArray &interp_state);
+void interpGRFArray(const quad_msgs::GRFArray &state_1,
+                    const quad_msgs::GRFArray &state_2, double t_interp,
+                    quad_msgs::GRFArray &interp_state);
 
 /**
  * @brief Interpolate data between two RobotState messages.

--- a/quad_utils/include/quad_utils/ros_utils.h
+++ b/quad_utils/include/quad_utils/ros_utils.h
@@ -14,8 +14,8 @@ namespace quad_utils {
  * @param[in] t_compare ROS time we wish to compare to
  * @return Age in ms (compared to t_compare)
  */
-inline double getROSMessageAgeInMs(std_msgs::Header header,
-                                   ros::Time t_compare) {
+inline double getROSMessageAgeInMs(const std_msgs::Header &header,
+                                   const ros::Time &t_compare) {
   return (t_compare - header.stamp).toSec() * 1000.0;
 }
 
@@ -24,7 +24,7 @@ inline double getROSMessageAgeInMs(std_msgs::Header header,
  * @param[in] header ROS Header that we wish to compute the age of
  * @return Age in ms (compared to ros::Time::now())
  */
-inline double getROSMessageAgeInMs(std_msgs::Header header) {
+inline double getROSMessageAgeInMs(const std_msgs::Header &header) {
   ros::Time t_compare = ros::Time::now();
   return quad_utils::getROSMessageAgeInMs(header, t_compare);
 }
@@ -34,7 +34,7 @@ inline double getROSMessageAgeInMs(std_msgs::Header header) {
  * @param[in] plan_start ROS Time to to compare to
  * @return Time in plan (compared to ros::Time::now())
  */
-inline double getDurationSinceTime(ros::Time plan_start) {
+inline double getDurationSinceTime(const ros::Time &plan_start) {
   return (ros::Time::now() - plan_start).toSec();
 }
 
@@ -46,7 +46,7 @@ inline double getDurationSinceTime(ros::Time plan_start) {
  * @param[in] plan_start ROS Time to to compare to
  * @param[in] dt Timestep used to discretize the plan
  */
-inline void getPlanIndex(ros::Time plan_start, double dt, int &index,
+inline void getPlanIndex(const ros::Time &plan_start, double dt, int &index,
                          double &first_element_duration) {
   double duration = getDurationSinceTime(plan_start);
   index = std::floor(duration / dt);
@@ -61,7 +61,7 @@ inline void getPlanIndex(ros::Time plan_start, double dt, int &index,
  * @return boolean success
  */
 template <class ParamType>
-inline bool loadROSParam(ros::NodeHandle nh, std::string paramName,
+inline bool loadROSParam(ros::NodeHandle nh, const std::string &paramName,
                          ParamType &varName) {
   if (!nh.getParam(paramName, varName)) {
     ROS_ERROR("Can't find param %s from parameter server", paramName.c_str());
@@ -80,8 +80,8 @@ inline bool loadROSParam(ros::NodeHandle nh, std::string paramName,
  * @return boolean (true if found rosparam, false if loaded default)
  */
 template <class ParamType>
-inline bool loadROSParamDefault(ros::NodeHandle nh, std::string paramName,
-                                ParamType &varName, ParamType defaultVal) {
+inline bool loadROSParamDefault(ros::NodeHandle nh, const std::string &paramName,
+                                ParamType &varName, const ParamType &defaultVal) {
   if (!nh.getParam(paramName, varName)) {
     varName = defaultVal;
     ROS_INFO("Can't find param %s on rosparam server, loading default value.",
@@ -107,8 +107,8 @@ inline bool loadROSParamDefault(ros::NodeHandle nh, std::string paramName,
  * @param[in] frame Frame_id for the state message
  * @param[in] traj_index Trajectory index of this state message
  */
-void updateStateHeaders(quad_msgs::RobotState &msg, ros::Time stamp,
-                        std::string frame, int traj_index);
+void updateStateHeaders(quad_msgs::RobotState &msg, const ros::Time &stamp,
+                        const std::string &frame, int traj_index);
 
 /**
  * @brief Interpolate two headers
@@ -117,7 +117,7 @@ void updateStateHeaders(quad_msgs::RobotState &msg, ros::Time stamp,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated header
  */
-void interpHeader(std_msgs::Header header_1, std_msgs::Header header_2,
+void interpHeader(const std_msgs::Header &header_1, const std_msgs::Header &header_2,
                   double t_interp, std_msgs::Header &interp_header);
 
 /**
@@ -127,7 +127,7 @@ void interpHeader(std_msgs::Header header_1, std_msgs::Header header_2,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated Odometry message
  */
-void interpOdometry(quad_msgs::BodyState state_1, quad_msgs::BodyState state_2,
+void interpOdometry(const quad_msgs::BodyState &state_1, const quad_msgs::BodyState &state_2,
                     double t_interp, quad_msgs::BodyState &interp_state);
 
 /**
@@ -137,8 +137,8 @@ void interpOdometry(quad_msgs::BodyState state_1, quad_msgs::BodyState state_2,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated JointState message
  */
-void interpJointState(sensor_msgs::JointState state_1,
-                      sensor_msgs::JointState state_2, double t_interp,
+void interpJointState(const sensor_msgs::JointState &state_1,
+                      const sensor_msgs::JointState &state_2, double t_interp,
                       sensor_msgs::JointState &interp_state);
 
 /**
@@ -148,8 +148,8 @@ void interpJointState(sensor_msgs::JointState state_1,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated FootState message
  */
-void interpMultiFootState(quad_msgs::MultiFootState state_1,
-                          quad_msgs::MultiFootState state_2, double t_interp,
+void interpMultiFootState(const quad_msgs::MultiFootState &state_1,
+                          const quad_msgs::MultiFootState &state_2, double t_interp,
                           quad_msgs::MultiFootState &interp_state);
 
 /**
@@ -159,7 +159,7 @@ void interpMultiFootState(quad_msgs::MultiFootState state_1,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated GRFArray message
  */
-void interpGRFArray(quad_msgs::GRFArray state_1, quad_msgs::GRFArray state_2,
+void interpGRFArray(const quad_msgs::GRFArray &state_1, const quad_msgs::GRFArray &state_2,
                     double t_interp, quad_msgs::GRFArray &interp_state);
 
 /**
@@ -169,8 +169,8 @@ void interpGRFArray(quad_msgs::GRFArray state_1, quad_msgs::GRFArray state_2,
  * @param[in] t_interp Fraction of time between the messages [0,1]
  * @param[out] interp_state Interpolated RobotState message
  */
-void interpRobotState(quad_msgs::RobotState state_1,
-                      quad_msgs::RobotState state_2, double t_interp,
+void interpRobotState(const quad_msgs::RobotState &state_1,
+                      const quad_msgs::RobotState &state_2, double t_interp,
                       quad_msgs::RobotState &interp_state);
 
 /**
@@ -182,7 +182,7 @@ void interpRobotState(quad_msgs::RobotState state_1,
  * @param[out] interp_primitive_id Interpolated primitive id
  * @param[out] interp_grf Interpolated GRF array
  */
-void interpRobotPlan(quad_msgs::RobotPlan msg, double t,
+void interpRobotPlan(const quad_msgs::RobotPlan &msg, double t,
                      quad_msgs::RobotState &interp_state,
                      int &interp_primitive_id, quad_msgs::GRFArray &interp_grf);
 
@@ -194,7 +194,7 @@ void interpRobotPlan(quad_msgs::RobotPlan msg, double t,
  * @return MultiFootState message
  */
 quad_msgs::MultiFootState interpMultiFootPlanContinuous(
-    quad_msgs::MultiFootPlanContinuous msg, double t);
+    const quad_msgs::MultiFootPlanContinuous &msg, double t);
 
 // /**
 //  * @brief Interpolate data from a robot state trajectory message.
@@ -216,8 +216,8 @@ quad_msgs::MultiFootState interpMultiFootPlanContinuous(
  * @param[out] joint_state message of the corresponding joint state
  */
 void ikRobotState(const quad_utils::QuadKD &kinematics,
-                  quad_msgs::BodyState body_state,
-                  quad_msgs::MultiFootState multi_foot_state,
+                  const quad_msgs::BodyState &body_state,
+                  const quad_msgs::MultiFootState &multi_foot_state,
                   sensor_msgs::JointState &joint_state);
 
 /**
@@ -237,8 +237,8 @@ void ikRobotState(const quad_utils::QuadKD &kinematics,
  * @param[out] multi_foot_state message of state of each foot
  */
 void fkRobotState(const quad_utils::QuadKD &kinematics,
-                  quad_msgs::BodyState body_state,
-                  sensor_msgs::JointState joint_state,
+                  const quad_msgs::BodyState &body_state,
+                  const sensor_msgs::JointState &joint_state,
                   quad_msgs::MultiFootState &multi_foot_state);
 
 /**
@@ -270,8 +270,8 @@ Eigen::VectorXd bodyStateMsgToEigen(const quad_msgs::BodyState &body);
  * information
  * @param[out] grf_msg GRFArray msg containing GRF data
  */
-void eigenToGRFArrayMsg(Eigen::VectorXd grf_array,
-                        quad_msgs::MultiFootState multi_foot_state_msg,
+void eigenToGRFArrayMsg(const Eigen::VectorXd &grf_array,
+                        const quad_msgs::MultiFootState &multi_foot_state_msg,
                         quad_msgs::GRFArray &grf_msg);
 
 /**
@@ -331,8 +331,8 @@ void multiFootStateMsgToEigen(
  * @param[out] foot_state_msg FootState msg containing foot position and
  * velocity data
  */
-void eigenToFootStateMsg(Eigen::VectorXd foot_position,
-                         Eigen::VectorXd foot_velocity,
+void eigenToFootStateMsg(const Eigen::VectorXd &foot_position,
+                         const Eigen::VectorXd &foot_velocity,
                          quad_msgs::FootState &foot_state_msg);
 
 /**
@@ -343,9 +343,9 @@ void eigenToFootStateMsg(Eigen::VectorXd foot_position,
  * @param[out] foot_state_msg FootState msg containing foot position and
  * velocity data
  */
-void eigenToFootStateMsg(Eigen::VectorXd foot_position,
-                         Eigen::VectorXd foot_velocity,
-                         Eigen::VectorXd foot_acceleration,
+void eigenToFootStateMsg(const Eigen::VectorXd &foot_position,
+                         const Eigen::VectorXd &foot_velocity,
+                         const Eigen::VectorXd &foot_acceleration,
                          quad_msgs::FootState &foot_state_msg);
 
 /**

--- a/quad_utils/src/math_utils.cpp
+++ b/quad_utils/src/math_utils.cpp
@@ -5,215 +5,221 @@ namespace math_utils {
 std::vector<double> interpMat(const std::vector<double> &input_vec,
                               const std::vector<std::vector<double>> &input_mat,
                               const double query_point) {
-  // Check bounds, throw an error if invalid since this shouldn't ever happen
-  if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
-    throw std::runtime_error("Tried to interp out of bounds");
-  }
-
-  // Declare variables for interpolating between, both for input and output data
-  double t1, t2;
-  std::vector<double> y1, y2, interp_data;
-
-  // Find the correct values to interp between
-  for (int i = 0; i < input_vec.size(); i++) {
-    if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
-      t1 = input_vec[i];
-      t2 = input_vec[i + 1];
-      y1 = input_mat[i];
-      y2 = input_mat[i + 1];
-      break;
+    // Check bounds, throw an error if invalid since this shouldn't ever happen
+    if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
+        throw std::runtime_error("Tried to interp out of bounds");
     }
-  }
 
-  // Apply linear interpolation for each element in the vector
-  for (int i = 0; i < input_mat.front().size(); i++) {
-    double result = y1[i] + (y2[i] - y1[i]) / (t2 - t1) * (query_point - t1);
-    interp_data.push_back(result);
-  }
+    // Declare variables for interpolating between, both for input and output
+    // data
+    double t1, t2;
+    std::vector<double> y1, y2, interp_data;
 
-  return interp_data;
+    // Find the correct values to interp between
+    for (int i = 0; i < input_vec.size(); i++) {
+        if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
+            t1 = input_vec[i];
+            t2 = input_vec[i + 1];
+            y1 = input_mat[i];
+            y2 = input_mat[i + 1];
+            break;
+        }
+    }
+
+    // Apply linear interpolation for each element in the vector
+    for (int i = 0; i < input_mat.front().size(); i++) {
+        double result =
+            y1[i] + (y2[i] - y1[i]) / (t2 - t1) * (query_point - t1);
+        interp_data.push_back(result);
+    }
+
+    return interp_data;
 }
 
 Eigen::Vector3d interpVector3d(const std::vector<double> &input_vec,
                                const std::vector<Eigen::Vector3d> &input_mat,
                                const double query_point) {
-  // Check bounds, throw an error if invalid since this shouldn't ever happen
-  if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
-    throw std::runtime_error("Tried to interp out of bounds");
-  }
-
-  // Declare variables for interpolating between, both for input and output data
-  double t1, t2;
-  Eigen::Vector3d y1, y2, interp_data;
-
-  // Find the correct values to interp between
-  for (int i = 0; i < input_vec.size(); i++) {
-    if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
-      t1 = input_vec[i];
-      t2 = input_vec[i + 1];
-      y1 = input_mat[i];
-      y2 = input_mat[i + 1];
-      break;
+    // Check bounds, throw an error if invalid since this shouldn't ever happen
+    if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
+        throw std::runtime_error("Tried to interp out of bounds");
     }
-  }
 
-  // Apply linear interpolation for each element in the vector
-  interp_data =
-      y1.array() + (y2.array() - y1.array()) / (t2 - t1) * (query_point - t1);
+    // Declare variables for interpolating between, both for input and output
+    // data
+    double t1, t2;
+    Eigen::Vector3d y1, y2, interp_data;
 
-  return interp_data;
+    // Find the correct values to interp between
+    for (int i = 0; i < input_vec.size(); i++) {
+        if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
+            t1 = input_vec[i];
+            t2 = input_vec[i + 1];
+            y1 = input_mat[i];
+            y2 = input_mat[i + 1];
+            break;
+        }
+    }
+
+    // Apply linear interpolation for each element in the vector
+    interp_data =
+        y1.array() + (y2.array() - y1.array()) / (t2 - t1) * (query_point - t1);
+
+    return interp_data;
 }
 
 std::vector<Eigen::Vector3d> interpMatVector3d(
     const std::vector<double> &input_vec,
     const std::vector<std::vector<Eigen::Vector3d>> &output_mat,
     const double query_point) {
-  // Check bounds, throw an error if invalid since this shouldn't ever happen
-  if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
-    throw std::runtime_error("Tried to interp out of bounds");
-  }
-
-  // Declare variables for interpolating between, both for input and output data
-  double t1, t2;
-  std::vector<Eigen::Vector3d> y1, y2, interp_data;
-
-  // Find the correct values to interp between
-  for (int i = 0; i < input_vec.size(); i++) {
-    if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
-      t1 = input_vec[i];
-      t2 = input_vec[i + 1];
-      y1 = output_mat[i];
-      y2 = output_mat[i + 1];
-      break;
+    // Check bounds, throw an error if invalid since this shouldn't ever happen
+    if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
+        throw std::runtime_error("Tried to interp out of bounds");
     }
-  }
 
-  // Apply linear interpolation for each element in the vector
-  for (int i = 0; i < output_mat.front().size(); i++) {
-    Eigen::Vector3d interp_eigen_vec;
-    interp_eigen_vec = y1[i].array() + (y2[i].array() - y1[i].array()) /
-                                           (t2 - t1) * (query_point - t1);
-    interp_data.push_back(interp_eigen_vec);
-  }
+    // Declare variables for interpolating between, both for input and output
+    // data
+    double t1, t2;
+    std::vector<Eigen::Vector3d> y1, y2, interp_data;
 
-  return interp_data;
+    // Find the correct values to interp between
+    for (int i = 0; i < input_vec.size(); i++) {
+        if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
+            t1 = input_vec[i];
+            t2 = input_vec[i + 1];
+            y1 = output_mat[i];
+            y2 = output_mat[i + 1];
+            break;
+        }
+    }
+
+    // Apply linear interpolation for each element in the vector
+    for (int i = 0; i < output_mat.front().size(); i++) {
+        Eigen::Vector3d interp_eigen_vec;
+        interp_eigen_vec = y1[i].array() + (y2[i].array() - y1[i].array()) /
+                                               (t2 - t1) * (query_point - t1);
+        interp_data.push_back(interp_eigen_vec);
+    }
+
+    return interp_data;
 }
 
-int interpInt(const std::vector<double> &input_vec, std::vector<int> &output_vec,
-              const double query_point) {
-  // Check bounds, throw an error if invalid since this shouldn't ever happen
-  if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
-    throw std::runtime_error("Tried to interp out of bounds");
-  }
-
-  // Declare variables for interpolating between, both for input and output data
-  double t1, t2;
-  Eigen::Vector3d y1, y2, interp_data;
-
-  // Find the correct values to interp between
-  int idx = 0;
-  for (int i = 0; i < input_vec.size(); i++) {
-    if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
-      return output_vec[i];
+int interpInt(const std::vector<double> &input_vec,
+              std::vector<int> &output_vec, const double query_point) {
+    // Check bounds, throw an error if invalid since this shouldn't ever happen
+    if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
+        throw std::runtime_error("Tried to interp out of bounds");
     }
-  }
 
-  throw std::runtime_error("Didn't find the query point, something happened");
+    // Declare variables for interpolating between, both for input and output
+    // data
+    double t1, t2;
+    Eigen::Vector3d y1, y2, interp_data;
+
+    // Find the correct values to interp between
+    int idx = 0;
+    for (int i = 0; i < input_vec.size(); i++) {
+        if (input_vec[i] <= query_point && query_point < input_vec[i + 1]) {
+            return output_vec[i];
+        }
+    }
+
+    throw std::runtime_error("Didn't find the query point, something happened");
 }
 
 std::vector<double> movingAverageFilter(const std::vector<double> &data,
                                         int window_size) {
-  std::vector<double> filtered_data;
-  int N = data.size();
+    std::vector<double> filtered_data;
+    int N = data.size();
 
-  // Check to ensure window size is an odd integer, if not add one to make it so
-  if ((window_size % 2) == 0) {
-    window_size += 1;
-    ROS_WARN_THROTTLE(
-        0.5, "Filter window size is even, adding one to maintain symmetry");
-  }
-
-  // Make sure that the window size is acceptable
-  if (window_size >= N) {
-    ROS_WARN_THROTTLE(0.5, "Filter window size is bigger than data");
-  }
-
-  // Loop through the data
-  for (int i = 0; i < N; i++) {
-    // Initialize sum and count of data samples
-    double sum = 0;
-    double count = 0;
-
-    // Shrink the window size if it would result in out of bounds data
-    int current_window_size = std::min(window_size, 2 * i + 1);
-    // int current_window_size = window_size;
-
-    // Loop through the window, adding to the sum and averaging
-    for (int j = 0; j < current_window_size; j++) {
-      double index = i + (j - (current_window_size - 1) / 2);
-
-      // Make sure data is in bounds
-      if (index >= 0 && index < N) {
-        sum += data[index];
-        count += 1;
-      }
+    // Check to ensure window size is an odd integer, if not add one to make it
+    // so
+    if ((window_size % 2) == 0) {
+        window_size += 1;
+        ROS_WARN_THROTTLE(
+            0.5, "Filter window size is even, adding one to maintain symmetry");
     }
 
-    filtered_data.push_back((float)sum / count);
-  }
+    // Make sure that the window size is acceptable
+    if (window_size >= N) {
+        ROS_WARN_THROTTLE(0.5, "Filter window size is bigger than data");
+    }
 
-  return filtered_data;
+    // Loop through the data
+    for (int i = 0; i < N; i++) {
+        // Initialize sum and count of data samples
+        double sum = 0;
+        double count = 0;
+
+        // Shrink the window size if it would result in out of bounds data
+        int current_window_size = std::min(window_size, 2 * i + 1);
+        // int current_window_size = window_size;
+
+        // Loop through the window, adding to the sum and averaging
+        for (int j = 0; j < current_window_size; j++) {
+            double index = i + (j - (current_window_size - 1) / 2);
+
+            // Make sure data is in bounds
+            if (index >= 0 && index < N) {
+                sum += data[index];
+                count += 1;
+            }
+        }
+
+        filtered_data.push_back((float)sum / count);
+    }
+
+    return filtered_data;
 }
 
 std::vector<double> centralDiff(const std::vector<double> &data, double dt) {
-  std::vector<double> data_diff;
+    std::vector<double> data_diff;
 
-  for (int i = 0; i < data.size(); i++) {
-    // Compute lower and upper indices, with forward/backward difference at the
-    // ends
-    int lower_index = std::max(i - 1, 0);
-    int upper_index = std::min(i + 1, (int)data.size() - 1);
+    for (int i = 0; i < data.size(); i++) {
+        // Compute lower and upper indices, with forward/backward difference at
+        // the ends
+        int lower_index = std::max(i - 1, 0);
+        int upper_index = std::min(i + 1, (int)data.size() - 1);
 
-    double estimate = (data[upper_index] - data[lower_index]) /
-                      (dt * (upper_index - lower_index));
-    data_diff.push_back(estimate);
-  }
+        double estimate = (data[upper_index] - data[lower_index]) /
+                          (dt * (upper_index - lower_index));
+        data_diff.push_back(estimate);
+    }
 
-  return data_diff;
+    return data_diff;
 }
 
 std::vector<double> unwrap(std::vector<double> data) {
-  std::vector<double> data_unwrapped = data;
-  for (int i = 1; i < data.size(); i++) {
-    double diff = data[i] - data[i - 1];
-    if (diff > M_PI) {
-      for (int j = i; j < data.size(); j++) {
-        data_unwrapped[j] = data_unwrapped[j] - 2 * M_PI;
-      }
-    } else if (diff < -M_PI) {
-      for (int j = i; j < data.size(); j++) {
-        data_unwrapped[j] = data_unwrapped[j] + 2 * M_PI;
-      }
+    std::vector<double> data_unwrapped = data;
+    for (int i = 1; i < data.size(); i++) {
+        double diff = data[i] - data[i - 1];
+        if (diff > M_PI) {
+            for (int j = i; j < data.size(); j++) {
+                data_unwrapped[j] = data_unwrapped[j] - 2 * M_PI;
+            }
+        } else if (diff < -M_PI) {
+            for (int j = i; j < data.size(); j++) {
+                data_unwrapped[j] = data_unwrapped[j] + 2 * M_PI;
+            }
+        }
     }
-  }
 
-  return data_unwrapped;
+    return data_unwrapped;
 }
 
 Eigen::MatrixXd sdlsInv(const Eigen::MatrixXd &jacobian) {
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd(
-      jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+        jacobian, Eigen::ComputeThinU | Eigen::ComputeThinV);
 
-  Eigen::VectorXd sig = svd.singularValues();
-  Eigen::VectorXd sig_inv = sig;
+    Eigen::VectorXd sig = svd.singularValues();
+    Eigen::VectorXd sig_inv = sig;
 
-  for (size_t i = 0; i < sig.size(); i++) {
-    sig_inv(i) = std::min(1 / sig(i), 1 / (1e-1 * sig.maxCoeff()));
-  }
+    for (size_t i = 0; i < sig.size(); i++) {
+        sig_inv(i) = std::min(1 / sig(i), 1 / (1e-1 * sig.maxCoeff()));
+    }
 
-  Eigen::MatrixXd jacobian_inv =
-      svd.matrixV() * sig_inv.asDiagonal() * svd.matrixU().transpose();
+    Eigen::MatrixXd jacobian_inv =
+        svd.matrixV() * sig_inv.asDiagonal() * svd.matrixU().transpose();
 
-  return jacobian_inv;
+    return jacobian_inv;
 }
 }  // namespace math_utils

--- a/quad_utils/src/math_utils.cpp
+++ b/quad_utils/src/math_utils.cpp
@@ -2,8 +2,8 @@
 
 namespace math_utils {
 
-std::vector<double> interpMat(const std::vector<double> input_vec,
-                              const std::vector<std::vector<double>> input_mat,
+std::vector<double> interpMat(const std::vector<double> &input_vec,
+                              const std::vector<std::vector<double>> &input_mat,
                               const double query_point) {
   // Check bounds, throw an error if invalid since this shouldn't ever happen
   if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
@@ -34,8 +34,8 @@ std::vector<double> interpMat(const std::vector<double> input_vec,
   return interp_data;
 }
 
-Eigen::Vector3d interpVector3d(const std::vector<double> input_vec,
-                               const std::vector<Eigen::Vector3d> input_mat,
+Eigen::Vector3d interpVector3d(const std::vector<double> &input_vec,
+                               const std::vector<Eigen::Vector3d> &input_mat,
                                const double query_point) {
   // Check bounds, throw an error if invalid since this shouldn't ever happen
   if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
@@ -65,8 +65,8 @@ Eigen::Vector3d interpVector3d(const std::vector<double> input_vec,
 }
 
 std::vector<Eigen::Vector3d> interpMatVector3d(
-    const std::vector<double> input_vec,
-    const std::vector<std::vector<Eigen::Vector3d>> output_mat,
+    const std::vector<double> &input_vec,
+    const std::vector<std::vector<Eigen::Vector3d>> &output_mat,
     const double query_point) {
   // Check bounds, throw an error if invalid since this shouldn't ever happen
   if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
@@ -99,7 +99,7 @@ std::vector<Eigen::Vector3d> interpMatVector3d(
   return interp_data;
 }
 
-int interpInt(const std::vector<double> input_vec, std::vector<int> output_vec,
+int interpInt(const std::vector<double> &input_vec, std::vector<int> &output_vec,
               const double query_point) {
   // Check bounds, throw an error if invalid since this shouldn't ever happen
   if ((query_point < input_vec.front()) || (query_point > input_vec.back())) {
@@ -121,7 +121,7 @@ int interpInt(const std::vector<double> input_vec, std::vector<int> output_vec,
   throw std::runtime_error("Didn't find the query point, something happened");
 }
 
-std::vector<double> movingAverageFilter(std::vector<double> data,
+std::vector<double> movingAverageFilter(const std::vector<double> &data,
                                         int window_size) {
   std::vector<double> filtered_data;
   int N = data.size();
@@ -165,7 +165,7 @@ std::vector<double> movingAverageFilter(std::vector<double> data,
   return filtered_data;
 }
 
-std::vector<double> centralDiff(std::vector<double> data, double dt) {
+std::vector<double> centralDiff(const std::vector<double> &data, double dt) {
   std::vector<double> data_diff;
 
   for (int i = 0; i < data.size(); i++) {

--- a/quad_utils/src/quad_kd.cpp
+++ b/quad_utils/src/quad_kd.cpp
@@ -9,240 +9,237 @@ QuadKD::QuadKD() { initModel(""); }
 QuadKD::QuadKD(const std::string &ns) { initModel("/" + ns + "/"); }
 
 void QuadKD::initModel(const std::string &ns) {
-  std::string robot_description_string;
+    std::string robot_description_string;
 
-  if (!ros::param::get("robot_description", robot_description_string)) {
-    std::cerr << "Error loading robot_description " << std::endl;
-    abort();
-  }
+    if (!ros::param::get("robot_description", robot_description_string)) {
+        std::cerr << "Error loading robot_description " << std::endl;
+        abort();
+    }
 
-  model_ = new RigidBodyDynamics::Model();
-  if (!RigidBodyDynamics::Addons::URDFReadFromString(
-          robot_description_string.c_str(), model_, true)) {
-    std::cerr << "Error loading model " << std::endl;
-    abort();
-  }
+    model_ = new RigidBodyDynamics::Model();
+    if (!RigidBodyDynamics::Addons::URDFReadFromString(
+            robot_description_string.c_str(), model_, true)) {
+        std::cerr << "Error loading model " << std::endl;
+        abort();
+    }
 
-  body_name_list_ = {"toe0", "toe1", "toe2", "toe3"};
+    body_name_list_ = {"toe0", "toe1", "toe2", "toe3"};
 
-  body_id_list_.resize(4);
-  for (size_t i = 0; i < body_name_list_.size(); i++) {
-    body_id_list_.at(i) = model_->GetBodyId(body_name_list_.at(i).c_str());
-  }
+    body_id_list_.resize(4);
+    for (size_t i = 0; i < body_name_list_.size(); i++) {
+        body_id_list_.at(i) = model_->GetBodyId(body_name_list_.at(i).c_str());
+    }
 
-  leg_idx_list_.resize(4);
-  std::iota(leg_idx_list_.begin(), leg_idx_list_.end(), 0);
-  std::sort(leg_idx_list_.begin(), leg_idx_list_.end(), [&](int i, int j) {
-    return body_id_list_.at(i) < body_id_list_.at(j);
-  });
+    leg_idx_list_.resize(4);
+    std::iota(leg_idx_list_.begin(), leg_idx_list_.end(), 0);
+    std::sort(leg_idx_list_.begin(), leg_idx_list_.end(), [&](int i, int j) {
+        return body_id_list_.at(i) < body_id_list_.at(j);
+    });
 
-  // Read leg geometry from URDF
-  legbase_offsets_.resize(4);
-  l0_vec_.resize(4);
-  std::vector<std::string> hip_name_list = {"hip0", "hip1", "hip2", "hip3"};
-  std::vector<std::string> upper_name_list = {"upper0", "upper1", "upper2",
-                                              "upper3"};
-  std::vector<std::string> lower_name_list = {"lower0", "lower1", "lower2",
-                                              "lower3"};
-  std::vector<std::string> toe_name_list = {"toe0", "toe1", "toe2", "toe3"};
-  RigidBodyDynamics::Math::SpatialTransform tform;
-  for (size_t i = 0; i < 4; i++) {
-    // From body COM to abad
-    tform =
-        model_->GetJointFrame(model_->GetBodyId(hip_name_list.at(i).c_str()));
-    legbase_offsets_[i] = tform.r;
+    // Read leg geometry from URDF
+    legbase_offsets_.resize(4);
+    l0_vec_.resize(4);
+    std::vector<std::string> hip_name_list = {"hip0", "hip1", "hip2", "hip3"};
+    std::vector<std::string> upper_name_list = {"upper0", "upper1", "upper2",
+                                                "upper3"};
+    std::vector<std::string> lower_name_list = {"lower0", "lower1", "lower2",
+                                                "lower3"};
+    std::vector<std::string> toe_name_list = {"toe0", "toe1", "toe2", "toe3"};
+    RigidBodyDynamics::Math::SpatialTransform tform;
+    for (size_t i = 0; i < 4; i++) {
+        // From body COM to abad
+        tform = model_->GetJointFrame(
+            model_->GetBodyId(hip_name_list.at(i).c_str()));
+        legbase_offsets_[i] = tform.r;
 
-    // From abad to hip
-    tform =
-        model_->GetJointFrame(model_->GetBodyId(upper_name_list.at(i).c_str()));
-    l0_vec_[i] = tform.r(1);
+        // From abad to hip
+        tform = model_->GetJointFrame(
+            model_->GetBodyId(upper_name_list.at(i).c_str()));
+        l0_vec_[i] = tform.r(1);
 
-    // From hip to knee (we know they should be the same and the equation in IK
-    // uses the magnitute of it)
-    tform =
-        model_->GetJointFrame(model_->GetBodyId(lower_name_list.at(i).c_str()));
-    l1_ = tform.r.cwiseAbs().maxCoeff();
-    knee_offset_ = tform.r;
+        // From hip to knee (we know they should be the same and the equation in
+        // IK uses the magnitute of it)
+        tform = model_->GetJointFrame(
+            model_->GetBodyId(lower_name_list.at(i).c_str()));
+        l1_ = tform.r.cwiseAbs().maxCoeff();
+        knee_offset_ = tform.r;
 
-    // From knee to toe (we know they should be the same and the equation in IK
-    // uses the magnitute of it)
-    tform =
-        model_->GetJointFrame(model_->GetBodyId(toe_name_list.at(i).c_str()));
-    l2_ = tform.r.cwiseAbs().maxCoeff();
-    foot_offset_ = tform.r;
-  }
+        // From knee to toe (we know they should be the same and the equation in
+        // IK uses the magnitute of it)
+        tform = model_->GetJointFrame(
+            model_->GetBodyId(toe_name_list.at(i).c_str()));
+        l2_ = tform.r.cwiseAbs().maxCoeff();
+        foot_offset_ = tform.r;
+    }
 
-  // Abad offset from legbase
-  abad_offset_ = {0, 0, 0};
+    // Abad offset from legbase
+    abad_offset_ = {0, 0, 0};
 
-  g_body_legbases_.resize(4);
-  for (int leg_index = 0; leg_index < 4; leg_index++) {
-    // Compute transforms
-    g_body_legbases_[leg_index] =
-        createAffineMatrix(legbase_offsets_[leg_index],
-                           Eigen::AngleAxisd(0, Eigen::Vector3d::UnitZ()));
-  }
+    g_body_legbases_.resize(4);
+    for (int leg_index = 0; leg_index < 4; leg_index++) {
+        // Compute transforms
+        g_body_legbases_[leg_index] =
+            createAffineMatrix(legbase_offsets_[leg_index],
+                               Eigen::AngleAxisd(0, Eigen::Vector3d::UnitZ()));
+    }
 
-  joint_min_.resize(num_feet_);
-  joint_max_.resize(num_feet_);
+    joint_min_.resize(num_feet_);
+    joint_max_.resize(num_feet_);
 
-  std::vector<double> joint_min_front = {-0.707, -M_PI * 0.5, 0};
-  std::vector<double> joint_min_back = {-0.707, -M_PI, 0};
-  std::vector<double> joint_max_front = {0.707, M_PI, M_PI};
-  std::vector<double> joint_max_back = {0.707, M_PI * 0.5, M_PI};
+    std::vector<double> joint_min_front = {-0.707, -M_PI * 0.5, 0};
+    std::vector<double> joint_min_back = {-0.707, -M_PI, 0};
+    std::vector<double> joint_max_front = {0.707, M_PI, M_PI};
+    std::vector<double> joint_max_back = {0.707, M_PI * 0.5, M_PI};
 
-  joint_min_ = {joint_min_front, joint_min_back, joint_min_front,
-                joint_min_back};
-  joint_max_ = {joint_max_front, joint_max_back, joint_max_front,
-                joint_max_back};
+    joint_min_ = {joint_min_front, joint_min_back, joint_min_front,
+                  joint_min_back};
+    joint_max_ = {joint_max_front, joint_max_back, joint_max_front,
+                  joint_max_back};
 }
 
 Eigen::Matrix4d QuadKD::createAffineMatrix(const Eigen::Vector3d &trans,
                                            const Eigen::Vector3d &rpy) const {
-  Eigen::Transform<double, 3, Eigen::Affine> t;
-  t = Eigen::Translation<double, 3>(trans);
-  t.rotate(Eigen::AngleAxisd(rpy[2], Eigen::Vector3d::UnitZ()));
-  t.rotate(Eigen::AngleAxisd(rpy[1], Eigen::Vector3d::UnitY()));
-  t.rotate(Eigen::AngleAxisd(rpy[0], Eigen::Vector3d::UnitX()));
+    Eigen::Transform<double, 3, Eigen::Affine> t;
+    t = Eigen::Translation<double, 3>(trans);
+    t.rotate(Eigen::AngleAxisd(rpy[2], Eigen::Vector3d::UnitZ()));
+    t.rotate(Eigen::AngleAxisd(rpy[1], Eigen::Vector3d::UnitY()));
+    t.rotate(Eigen::AngleAxisd(rpy[0], Eigen::Vector3d::UnitX()));
 
-  return t.matrix();
+    return t.matrix();
 }
 
 Eigen::Matrix4d QuadKD::createAffineMatrix(const Eigen::Vector3d &trans,
                                            const Eigen::AngleAxisd &rot) const {
-  Eigen::Transform<double, 3, Eigen::Affine> t;
-  t = Eigen::Translation<double, 3>(trans);
-  t.rotate(rot);
+    Eigen::Transform<double, 3, Eigen::Affine> t;
+    t = Eigen::Translation<double, 3>(trans);
+    t.rotate(rot);
 
-  return t.matrix();
+    return t.matrix();
 }
 
 double QuadKD::getJointLowerLimit(int leg_index, int joint_index) const {
-  return joint_min_[leg_index][joint_index];
+    return joint_min_[leg_index][joint_index];
 }
 
 double QuadKD::getJointUpperLimit(int leg_index, int joint_index) const {
-  return joint_max_[leg_index][joint_index];
+    return joint_max_[leg_index][joint_index];
 }
 
 double QuadKD::getLinkLength(int leg_index, int link_index) const {
-  switch (link_index) {
-    case 0:
-      return l0_vec_[leg_index];
-    case 1:
-      return l1_;
-    case 2:
-      return l2_;
-    default:
-      throw std::runtime_error("Invalid link index");
-  }
+    switch (link_index) {
+        case 0:
+            return l0_vec_[leg_index];
+        case 1:
+            return l1_;
+        case 2:
+            return l2_;
+        default:
+            throw std::runtime_error("Invalid link index");
+    }
 }
 
 void QuadKD::transformBodyToWorld(const Eigen::Vector3d &body_pos,
                                   const Eigen::Vector3d &body_rpy,
                                   const Eigen::Matrix4d &transform_body,
                                   Eigen::Matrix4d &transform_world) const {
-  // Compute transform from world to body frame
-  Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
+    // Compute transform from world to body frame
+    Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
 
-  // Get the desired transform in the world frame
-  transform_world = g_world_body * transform_body;
+    // Get the desired transform in the world frame
+    transform_world = g_world_body * transform_body;
 }
 
 void QuadKD::transformWorldToBody(const Eigen::Vector3d &body_pos,
                                   const Eigen::Vector3d &body_rpy,
                                   const Eigen::Matrix4d &transform_world,
                                   Eigen::Matrix4d &transform_body) const {
-  // Compute transform from world to body frame
-  Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
+    // Compute transform from world to body frame
+    Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
 
-  // Compute the desired transform in the body frame
-  transform_body = g_world_body.inverse() * transform_world;
+    // Compute the desired transform in the body frame
+    transform_body = g_world_body.inverse() * transform_world;
 }
 
 void QuadKD::worldToLegbaseFKWorldFrame(
-    int leg_index,
-    const Eigen::Vector3d &body_pos,
-    const Eigen::Vector3d &body_rpy,
-    Eigen::Matrix4d &g_world_legbase) const {
-  // Compute transforms
-  Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
+    int leg_index, const Eigen::Vector3d &body_pos,
+    const Eigen::Vector3d &body_rpy, Eigen::Matrix4d &g_world_legbase) const {
+    // Compute transforms
+    Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
 
-  // Compute transform for leg base relative to the world frame
-  g_world_legbase = g_world_body * g_body_legbases_[leg_index];
+    // Compute transform for leg base relative to the world frame
+    g_world_legbase = g_world_body * g_body_legbases_[leg_index];
 }
 
 void QuadKD::worldToLegbaseFKWorldFrame(
-    int leg_index,
-    const Eigen::Vector3d &body_pos,
+    int leg_index, const Eigen::Vector3d &body_pos,
     const Eigen::Vector3d &body_rpy,
     Eigen::Vector3d &leg_base_pos_world) const {
-  Eigen::Matrix4d g_world_legbase;
-  worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
+    Eigen::Matrix4d g_world_legbase;
+    worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
 
-  leg_base_pos_world = g_world_legbase.block<3, 1>(0, 3);
+    leg_base_pos_world = g_world_legbase.block<3, 1>(0, 3);
 }
 
 void QuadKD::worldToNominalHipFKWorldFrame(
-    int leg_index,
-    const Eigen::Vector3d &body_pos,
+    int leg_index, const Eigen::Vector3d &body_pos,
     const Eigen::Vector3d &body_rpy,
     Eigen::Vector3d &nominal_hip_pos_world) const {
-  // Compute transforms
-  Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
-  // Compute transform from body to legbase but offset by l0
-  Eigen::Matrix4d g_body_nominal_hip = g_body_legbases_[leg_index];
-  g_body_nominal_hip(1, 3) += 1.0 * l0_vec_[leg_index];
+    // Compute transforms
+    Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
+    // Compute transform from body to legbase but offset by l0
+    Eigen::Matrix4d g_body_nominal_hip = g_body_legbases_[leg_index];
+    g_body_nominal_hip(1, 3) += 1.0 * l0_vec_[leg_index];
 
-  // Compute transform for offset leg base relative to the world frame
-  Eigen::Matrix4d g_world_nominal_hip = g_world_body * g_body_nominal_hip;
+    // Compute transform for offset leg base relative to the world frame
+    Eigen::Matrix4d g_world_nominal_hip = g_world_body * g_body_nominal_hip;
 
-  nominal_hip_pos_world = g_world_nominal_hip.block<3, 1>(0, 3);
+    nominal_hip_pos_world = g_world_nominal_hip.block<3, 1>(0, 3);
 }
 
 void QuadKD::bodyToFootFKBodyFrame(int leg_index,
                                    const Eigen::Vector3d &joint_state,
                                    Eigen::Matrix4d &g_body_foot) const {
-  if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
-    throw std::runtime_error("Leg index is outside valid range");
-  }
+    if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
+        throw std::runtime_error("Leg index is outside valid range");
+    }
 
-  // Define hip offset
-  Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
+    // Define hip offset
+    Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
 
-  // Initialize transforms
-  Eigen::Matrix4d g_legbase_abad;
-  Eigen::Matrix4d g_abad_hip;
-  Eigen::Matrix4d g_hip_knee;
-  Eigen::Matrix4d g_knee_foot;
+    // Initialize transforms
+    Eigen::Matrix4d g_legbase_abad;
+    Eigen::Matrix4d g_abad_hip;
+    Eigen::Matrix4d g_hip_knee;
+    Eigen::Matrix4d g_knee_foot;
 
-  g_legbase_abad = createAffineMatrix(
-      abad_offset_,
-      Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
+    g_legbase_abad = createAffineMatrix(
+        abad_offset_,
+        Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
 
-  g_abad_hip = createAffineMatrix(
-      hip_offset, Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
+    g_abad_hip = createAffineMatrix(
+        hip_offset,
+        Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
 
-  g_hip_knee = createAffineMatrix(
-      knee_offset_,
-      Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
+    g_hip_knee = createAffineMatrix(
+        knee_offset_,
+        Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
 
-  g_knee_foot = createAffineMatrix(
-      foot_offset_, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
+    g_knee_foot = createAffineMatrix(
+        foot_offset_, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
 
-  // Get foot transform in world frame
-  g_body_foot = g_body_legbases_[leg_index] * g_legbase_abad * g_abad_hip *
-                g_hip_knee * g_knee_foot;
+    // Get foot transform in world frame
+    g_body_foot = g_body_legbases_[leg_index] * g_legbase_abad * g_abad_hip *
+                  g_hip_knee * g_knee_foot;
 }
 
 void QuadKD::bodyToFootFKBodyFrame(int leg_index,
                                    const Eigen::Vector3d &joint_state,
                                    Eigen::Vector3d &foot_pos_body) const {
-  Eigen::Matrix4d g_body_foot;
-  QuadKD::bodyToFootFKBodyFrame(leg_index, joint_state, g_body_foot);
+    Eigen::Matrix4d g_body_foot;
+    QuadKD::bodyToFootFKBodyFrame(leg_index, joint_state, g_body_foot);
 
-  // Extract cartesian position of foot
-  foot_pos_body = g_body_foot.block<3, 1>(0, 3);
+    // Extract cartesian position of foot
+    foot_pos_body = g_body_foot.block<3, 1>(0, 3);
 }
 
 void QuadKD::worldToFootFKWorldFrame(int leg_index,
@@ -250,41 +247,42 @@ void QuadKD::worldToFootFKWorldFrame(int leg_index,
                                      const Eigen::Vector3d &body_rpy,
                                      const Eigen::Vector3d &joint_state,
                                      Eigen::Matrix4d &g_world_foot) const {
-  if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
-    throw std::runtime_error("Leg index is outside valid range");
-  }
+    if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
+        throw std::runtime_error("Leg index is outside valid range");
+    }
 
-  // Define hip offset
-  Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
+    // Define hip offset
+    Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
 
-  // Initialize transforms
-  Eigen::Matrix4d g_body_legbase;
-  Eigen::Matrix4d g_legbase_abad;
-  Eigen::Matrix4d g_abad_hip;
-  Eigen::Matrix4d g_hip_knee;
-  Eigen::Matrix4d g_knee_foot;
+    // Initialize transforms
+    Eigen::Matrix4d g_body_legbase;
+    Eigen::Matrix4d g_legbase_abad;
+    Eigen::Matrix4d g_abad_hip;
+    Eigen::Matrix4d g_hip_knee;
+    Eigen::Matrix4d g_knee_foot;
 
-  // Compute transforms
-  Eigen::Matrix4d g_world_legbase;
-  worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
+    // Compute transforms
+    Eigen::Matrix4d g_world_legbase;
+    worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
 
-  g_legbase_abad = createAffineMatrix(
-      abad_offset_,
-      Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
+    g_legbase_abad = createAffineMatrix(
+        abad_offset_,
+        Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
 
-  g_abad_hip = createAffineMatrix(
-      hip_offset, Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
+    g_abad_hip = createAffineMatrix(
+        hip_offset,
+        Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
 
-  g_hip_knee = createAffineMatrix(
-      knee_offset_,
-      Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
+    g_hip_knee = createAffineMatrix(
+        knee_offset_,
+        Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
 
-  g_knee_foot = createAffineMatrix(
-      foot_offset_, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
+    g_knee_foot = createAffineMatrix(
+        foot_offset_, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
 
-  // Get foot transform in world frame
-  g_world_foot =
-      g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee * g_knee_foot;
+    // Get foot transform in world frame
+    g_world_foot = g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee *
+                   g_knee_foot;
 }
 
 void QuadKD::worldToFootFKWorldFrame(int leg_index,
@@ -292,12 +290,12 @@ void QuadKD::worldToFootFKWorldFrame(int leg_index,
                                      const Eigen::Vector3d &body_rpy,
                                      const Eigen::Vector3d &joint_state,
                                      Eigen::Vector3d &foot_pos_world) const {
-  Eigen::Matrix4d g_world_foot;
-  worldToFootFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
-                          g_world_foot);
+    Eigen::Matrix4d g_world_foot;
+    worldToFootFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
+                            g_world_foot);
 
-  // Extract cartesian position of foot
-  foot_pos_world = g_world_foot.block<3, 1>(0, 3);
+    // Extract cartesian position of foot
+    foot_pos_world = g_world_foot.block<3, 1>(0, 3);
 }
 
 void QuadKD::worldToKneeFKWorldFrame(int leg_index,
@@ -305,36 +303,37 @@ void QuadKD::worldToKneeFKWorldFrame(int leg_index,
                                      const Eigen::Vector3d &body_rpy,
                                      const Eigen::Vector3d &joint_state,
                                      Eigen::Matrix4d &g_world_knee) const {
-  if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
-    throw std::runtime_error("Leg index is outside valid range");
-  }
+    if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
+        throw std::runtime_error("Leg index is outside valid range");
+    }
 
-  // Define hip offset
-  Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
+    // Define hip offset
+    Eigen::Vector3d hip_offset = {0, l0_vec_[leg_index], 0};
 
-  // Initialize transforms
-  Eigen::Matrix4d g_body_legbase;
-  Eigen::Matrix4d g_legbase_abad;
-  Eigen::Matrix4d g_abad_hip;
-  Eigen::Matrix4d g_hip_knee;
+    // Initialize transforms
+    Eigen::Matrix4d g_body_legbase;
+    Eigen::Matrix4d g_legbase_abad;
+    Eigen::Matrix4d g_abad_hip;
+    Eigen::Matrix4d g_hip_knee;
 
-  // Compute transforms
-  Eigen::Matrix4d g_world_legbase;
-  worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
+    // Compute transforms
+    Eigen::Matrix4d g_world_legbase;
+    worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
 
-  g_legbase_abad = createAffineMatrix(
-      abad_offset_,
-      Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
+    g_legbase_abad = createAffineMatrix(
+        abad_offset_,
+        Eigen::AngleAxisd(joint_state[0], Eigen::Vector3d::UnitX()));
 
-  g_abad_hip = createAffineMatrix(
-      hip_offset, Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
+    g_abad_hip = createAffineMatrix(
+        hip_offset,
+        Eigen::AngleAxisd(joint_state[1], -Eigen::Vector3d::UnitY()));
 
-  g_hip_knee = createAffineMatrix(
-      knee_offset_,
-      Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
+    g_hip_knee = createAffineMatrix(
+        knee_offset_,
+        Eigen::AngleAxisd(joint_state[2], Eigen::Vector3d::UnitY()));
 
-  // Get foot transform in world frame
-  g_world_knee = g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee;
+    // Get foot transform in world frame
+    g_world_knee = g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee;
 }
 
 void QuadKD::worldToKneeFKWorldFrame(int leg_index,
@@ -342,12 +341,12 @@ void QuadKD::worldToKneeFKWorldFrame(int leg_index,
                                      const Eigen::Vector3d &body_rpy,
                                      const Eigen::Vector3d &joint_state,
                                      Eigen::Vector3d &knee_pos_world) const {
-  Eigen::Matrix4d g_world_knee;
-  worldToKneeFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
-                          g_world_knee);
+    Eigen::Matrix4d g_world_knee;
+    worldToKneeFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
+                            g_world_knee);
 
-  // Extract cartesian position of foot
-  knee_pos_world = g_world_knee.block<3, 1>(0, 3);
+    // Extract cartesian position of foot
+    knee_pos_world = g_world_knee.block<3, 1>(0, 3);
 }
 
 bool QuadKD::worldToFootIKWorldFrame(int leg_index,
@@ -355,225 +354,233 @@ bool QuadKD::worldToFootIKWorldFrame(int leg_index,
                                      const Eigen::Vector3d &body_rpy,
                                      const Eigen::Vector3d &foot_pos_world,
                                      Eigen::Vector3d &joint_state) const {
-  if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
-    throw std::runtime_error("Leg index is outside valid range");
-  }
+    if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
+        throw std::runtime_error("Leg index is outside valid range");
+    }
 
-  // Calculate offsets
-  Eigen::Vector3d legbase_offset = legbase_offsets_[leg_index];
-  double l0 = l0_vec_[leg_index];
+    // Calculate offsets
+    Eigen::Vector3d legbase_offset = legbase_offsets_[leg_index];
+    double l0 = l0_vec_[leg_index];
 
-  // Initialize transforms
-  Eigen::Matrix4d g_world_legbase;
-  Eigen::Matrix4d g_world_foot;
-  Eigen::Matrix4d g_legbase_foot;
-  Eigen::Vector3d foot_pos_legbase;
+    // Initialize transforms
+    Eigen::Matrix4d g_world_legbase;
+    Eigen::Matrix4d g_world_foot;
+    Eigen::Matrix4d g_legbase_foot;
+    Eigen::Vector3d foot_pos_legbase;
 
-  // Compute transforms
-  worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
+    // Compute transforms
+    worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
 
-  g_world_foot = createAffineMatrix(
-      foot_pos_world, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
+    g_world_foot = createAffineMatrix(
+        foot_pos_world, Eigen::AngleAxisd(0, Eigen::Vector3d::UnitY()));
 
-  // Compute foot position relative to the leg base in cartesian coordinates
-  g_legbase_foot = g_world_legbase.inverse() * g_world_foot;
-  foot_pos_legbase = g_legbase_foot.block<3, 1>(0, 3);
+    // Compute foot position relative to the leg base in cartesian coordinates
+    g_legbase_foot = g_world_legbase.inverse() * g_world_foot;
+    foot_pos_legbase = g_legbase_foot.block<3, 1>(0, 3);
 
-  return legbaseToFootIKLegbaseFrame(leg_index, foot_pos_legbase, joint_state);
+    return legbaseToFootIKLegbaseFrame(leg_index, foot_pos_legbase,
+                                       joint_state);
 }
 
-bool QuadKD::legbaseToFootIKLegbaseFrame(int leg_index,
-                                         const Eigen::Vector3d &foot_pos_legbase,
-                                         Eigen::Vector3d &joint_state) const {
-  // Initialize exact bool
-  bool is_exact = true;
+bool QuadKD::legbaseToFootIKLegbaseFrame(
+    int leg_index, const Eigen::Vector3d &foot_pos_legbase,
+    Eigen::Vector3d &joint_state) const {
+    // Initialize exact bool
+    bool is_exact = true;
 
-  // Calculate offsets
-  Eigen::Vector3d legbase_offset = legbase_offsets_[leg_index];
-  double l0 = l0_vec_[leg_index];
+    // Calculate offsets
+    Eigen::Vector3d legbase_offset = legbase_offsets_[leg_index];
+    double l0 = l0_vec_[leg_index];
 
-  // Extract coordinates and declare joint variables
-  double x = foot_pos_legbase[0];
-  double y = foot_pos_legbase[1];
-  double z = foot_pos_legbase[2];
-  double q0;
-  double q1;
-  double q2;
+    // Extract coordinates and declare joint variables
+    double x = foot_pos_legbase[0];
+    double y = foot_pos_legbase[1];
+    double z = foot_pos_legbase[2];
+    double q0;
+    double q1;
+    double q2;
 
-  // Start IK, check foot pos is at least l0 away from leg base, clamp otherwise
-  double temp = l0 / sqrt(z * z + y * y);
-  if (abs(temp) > 1) {
-    ROS_DEBUG_THROTTLE(0.5, "Foot too close, choosing closest alternative\n");
-    is_exact = false;
-    temp = std::max(std::min(temp, 1.0), -1.0);
-  }
+    // Start IK, check foot pos is at least l0 away from leg base, clamp
+    // otherwise
+    double temp = l0 / sqrt(z * z + y * y);
+    if (abs(temp) > 1) {
+        ROS_DEBUG_THROTTLE(0.5,
+                           "Foot too close, choosing closest alternative\n");
+        is_exact = false;
+        temp = std::max(std::min(temp, 1.0), -1.0);
+    }
 
-  // Compute both solutions of q0, use hip-above-knee if z<0 (preferred)
-  // Store the inverted solution in case hip limits are exceeded
-  if (z > 0) {
-    q0 = -acos(temp) + atan2(z, y);
-  } else {
-    q0 = acos(temp) + atan2(z, y);
-  }
+    // Compute both solutions of q0, use hip-above-knee if z<0 (preferred)
+    // Store the inverted solution in case hip limits are exceeded
+    if (z > 0) {
+        q0 = -acos(temp) + atan2(z, y);
+    } else {
+        q0 = acos(temp) + atan2(z, y);
+    }
 
-  // Make sure abad is within joint limits, clamp otherwise
-  if (q0 > joint_max_[leg_index][0] || q0 < joint_min_[leg_index][0]) {
-    q0 = std::max(std::min(q0, joint_max_[leg_index][0]),
-                  joint_min_[leg_index][0]);
-    is_exact = false;
-    ROS_DEBUG_THROTTLE(0.5, "Abad limits exceeded, clamping to %5.3f \n", q0);
-  }
+    // Make sure abad is within joint limits, clamp otherwise
+    if (q0 > joint_max_[leg_index][0] || q0 < joint_min_[leg_index][0]) {
+        q0 = std::max(std::min(q0, joint_max_[leg_index][0]),
+                      joint_min_[leg_index][0]);
+        is_exact = false;
+        ROS_DEBUG_THROTTLE(0.5, "Abad limits exceeded, clamping to %5.3f \n",
+                           q0);
+    }
 
-  // Rotate to ab-ad fixed frame
-  double z_body_frame = z;
-  z = -sin(q0) * y + cos(q0) * z_body_frame;
+    // Rotate to ab-ad fixed frame
+    double z_body_frame = z;
+    z = -sin(q0) * y + cos(q0) * z_body_frame;
 
-  // Check reachibility for hip
-  double acos_eps = 1.0;
-  double temp2 =
-      (l1_ * l1_ + x * x + z * z - l2_ * l2_) / (2 * l1_ * sqrt(x * x + z * z));
-  if (abs(temp2) > acos_eps) {
-    ROS_DEBUG_THROTTLE(0.5,
-                       "Foot location too far for hip, choosing closest"
-                       " alternative \n");
-    is_exact = false;
-    temp2 = std::max(std::min(temp2, acos_eps), -acos_eps);
-  }
+    // Check reachibility for hip
+    double acos_eps = 1.0;
+    double temp2 = (l1_ * l1_ + x * x + z * z - l2_ * l2_) /
+                   (2 * l1_ * sqrt(x * x + z * z));
+    if (abs(temp2) > acos_eps) {
+        ROS_DEBUG_THROTTLE(0.5,
+                           "Foot location too far for hip, choosing closest"
+                           " alternative \n");
+        is_exact = false;
+        temp2 = std::max(std::min(temp2, acos_eps), -acos_eps);
+    }
 
-  // Check reachibility for knee
-  double temp3 = (l1_ * l1_ + l2_ * l2_ - x * x - z * z) / (2 * l1_ * l2_);
+    // Check reachibility for knee
+    double temp3 = (l1_ * l1_ + l2_ * l2_ - x * x - z * z) / (2 * l1_ * l2_);
 
-  if (temp3 > acos_eps || temp3 < -acos_eps) {
-    ROS_DEBUG_THROTTLE(0.5,
-                       "Foot location too far for knee, choosing closest"
-                       " alternative \n");
-    is_exact = false;
+    if (temp3 > acos_eps || temp3 < -acos_eps) {
+        ROS_DEBUG_THROTTLE(0.5,
+                           "Foot location too far for knee, choosing closest"
+                           " alternative \n");
+        is_exact = false;
 
-    temp3 = std::max(std::min(temp3, acos_eps), -acos_eps);
-  }
+        temp3 = std::max(std::min(temp3, acos_eps), -acos_eps);
+    }
 
-  // Compute joint angles
-  q1 = 0.5 * M_PI + atan2(x, -z) - acos(temp2);
+    // Compute joint angles
+    q1 = 0.5 * M_PI + atan2(x, -z) - acos(temp2);
 
-  // Make sure hip is within joint limits
-  if (q1 > joint_max_[leg_index][1] || q1 < joint_min_[leg_index][1]) {
-    q1 = std::max(std::min(q1, joint_max_[leg_index][1]),
-                  joint_min_[leg_index][1]);
-    is_exact = false;
-    ROS_DEBUG_THROTTLE(0.5, "Hip limits exceeded, clamping to %5.3f \n", q1);
-  }
+    // Make sure hip is within joint limits
+    if (q1 > joint_max_[leg_index][1] || q1 < joint_min_[leg_index][1]) {
+        q1 = std::max(std::min(q1, joint_max_[leg_index][1]),
+                      joint_min_[leg_index][1]);
+        is_exact = false;
+        ROS_DEBUG_THROTTLE(0.5, "Hip limits exceeded, clamping to %5.3f \n",
+                           q1);
+    }
 
-  // Compute knee val to get closest toe position in the plane
-  Eigen::Vector2d knee_pos, toe_pos, toe_offset;
-  knee_pos << -l1_ * cos(q1), -l1_ * sin(q1);
-  toe_pos << x, z;
-  toe_offset = toe_pos - knee_pos;
-  q2 = atan2(-toe_offset(1), toe_offset(0)) + q1;
+    // Compute knee val to get closest toe position in the plane
+    Eigen::Vector2d knee_pos, toe_pos, toe_offset;
+    knee_pos << -l1_ * cos(q1), -l1_ * sin(q1);
+    toe_pos << x, z;
+    toe_offset = toe_pos - knee_pos;
+    q2 = atan2(-toe_offset(1), toe_offset(0)) + q1;
 
-  // Make sure knee is within joint limits
-  if (q2 > joint_max_[leg_index][2] || q2 < joint_min_[leg_index][2]) {
-    q2 = std::max(std::min(q2, joint_max_[leg_index][2]),
-                  joint_min_[leg_index][2]);
-    is_exact = false;
-    ROS_DEBUG_THROTTLE(0.5, "Knee limit exceeded, clamping to %5.3f \n", q2);
-  }
+    // Make sure knee is within joint limits
+    if (q2 > joint_max_[leg_index][2] || q2 < joint_min_[leg_index][2]) {
+        q2 = std::max(std::min(q2, joint_max_[leg_index][2]),
+                      joint_min_[leg_index][2]);
+        is_exact = false;
+        ROS_DEBUG_THROTTLE(0.5, "Knee limit exceeded, clamping to %5.3f \n",
+                           q2);
+    }
 
-  // q1 is undefined if q2=0, resolve this
-  if (q2 == 0) {
-    q1 = 0;
-    ROS_DEBUG_THROTTLE(0.5,
-                       "Hip value undefined (in singularity), setting to"
-                       " %5.3f \n",
-                       q1);
-    is_exact = false;
-  }
+    // q1 is undefined if q2=0, resolve this
+    if (q2 == 0) {
+        q1 = 0;
+        ROS_DEBUG_THROTTLE(0.5,
+                           "Hip value undefined (in singularity), setting to"
+                           " %5.3f \n",
+                           q1);
+        is_exact = false;
+    }
 
-  if (z_body_frame - l0 * sin(q0) > 0) {
-    ROS_DEBUG_THROTTLE(0.5, "IK solution is in hip-inverted region! Beware!\n");
-    is_exact = false;
-  }
+    if (z_body_frame - l0 * sin(q0) > 0) {
+        ROS_DEBUG_THROTTLE(0.5,
+                           "IK solution is in hip-inverted region! Beware!\n");
+        is_exact = false;
+    }
 
-  joint_state = {q0, q1, q2};
-  return is_exact;
+    joint_state = {q0, q1, q2};
+    return is_exact;
 }
 
 void QuadKD::getJacobianGenCoord(const Eigen::VectorXd &state,
                                  Eigen::MatrixXd &jacobian) const {
-  this->getJacobianBodyAngVel(state, jacobian);
+    this->getJacobianBodyAngVel(state, jacobian);
 
-  // RBDL uses Jacobian w.r.t. floating base angular velocity in body frame,
-  // which is multiplied by Jacobian to map it to Euler angle change rate here
-  for (size_t i = 0; i < 4; i++) {
-    Eigen::MatrixXd transform_jac(3, 3);
-    transform_jac << 1, 0, -sin(state(16)), 0, cos(state(15)),
-        cos(state(16)) * sin(state(15)), 0, -sin(state(15)),
-        cos(state(15)) * cos(state(16));
-    jacobian.block(3 * i, 15, 3, 3) =
-        jacobian.block(3 * i, 15, 3, 3) * transform_jac;
-  }
+    // RBDL uses Jacobian w.r.t. floating base angular velocity in body frame,
+    // which is multiplied by Jacobian to map it to Euler angle change rate here
+    for (size_t i = 0; i < 4; i++) {
+        Eigen::MatrixXd transform_jac(3, 3);
+        transform_jac << 1, 0, -sin(state(16)), 0, cos(state(15)),
+            cos(state(16)) * sin(state(15)), 0, -sin(state(15)),
+            cos(state(15)) * cos(state(16));
+        jacobian.block(3 * i, 15, 3, 3) =
+            jacobian.block(3 * i, 15, 3, 3) * transform_jac;
+    }
 }
 
 void QuadKD::getJacobianBodyAngVel(const Eigen::VectorXd &state,
                                    Eigen::MatrixXd &jacobian) const {
-  assert(state.size() == 18);
+    assert(state.size() == 18);
 
-  // RBDL state vector has the floating base state in the front and the joint
-  // state in the back When reading from URDF, the order of the legs is 2301,
-  // which should be corrected by sorting the bodyID
-  Eigen::VectorXd q(19);
-  q.setZero();
+    // RBDL state vector has the floating base state in the front and the joint
+    // state in the back When reading from URDF, the order of the legs is 2301,
+    // which should be corrected by sorting the bodyID
+    Eigen::VectorXd q(19);
+    q.setZero();
 
-  q.head(3) = state.segment(12, 3);
+    q.head(3) = state.segment(12, 3);
 
-  tf2::Quaternion quat_tf;
-  quat_tf.setRPY(state(15), state(16), state(17));
-  q(3) = quat_tf.getX();
-  q(4) = quat_tf.getY();
-  q(5) = quat_tf.getZ();
+    tf2::Quaternion quat_tf;
+    quat_tf.setRPY(state(15), state(16), state(17));
+    q(3) = quat_tf.getX();
+    q(4) = quat_tf.getY();
+    q(5) = quat_tf.getZ();
 
-  // RBDL uses quaternion for floating base direction, but w is placed at the
-  // end of the state vector
-  q(18) = quat_tf.getW();
+    // RBDL uses quaternion for floating base direction, but w is placed at the
+    // end of the state vector
+    q(18) = quat_tf.getW();
 
-  for (size_t i = 0; i < leg_idx_list_.size(); i++) {
-    q.segment(6 + 3 * i, 3) = state.segment(3 * leg_idx_list_.at(i), 3);
-  }
-
-  jacobian.setZero();
-
-  for (size_t i = 0; i < body_id_list_.size(); i++) {
-    Eigen::MatrixXd jac_block(3, 18);
-    jac_block.setZero();
-    RigidBodyDynamics::CalcPointJacobian(*model_, q, body_id_list_.at(i),
-                                         Eigen::Vector3d::Zero(), jac_block);
-
-    for (size_t j = 0; j < 4; j++) {
-      jacobian.block(3 * i, 3 * leg_idx_list_.at(j), 3, 3) =
-          jac_block.block(0, 6 + 3 * j, 3, 3);
+    for (size_t i = 0; i < leg_idx_list_.size(); i++) {
+        q.segment(6 + 3 * i, 3) = state.segment(3 * leg_idx_list_.at(i), 3);
     }
-    jacobian.block(3 * i, 12, 3, 6) = jac_block.block(0, 0, 3, 6);
-  }
+
+    jacobian.setZero();
+
+    for (size_t i = 0; i < body_id_list_.size(); i++) {
+        Eigen::MatrixXd jac_block(3, 18);
+        jac_block.setZero();
+        RigidBodyDynamics::CalcPointJacobian(*model_, q, body_id_list_.at(i),
+                                             Eigen::Vector3d::Zero(),
+                                             jac_block);
+
+        for (size_t j = 0; j < 4; j++) {
+            jacobian.block(3 * i, 3 * leg_idx_list_.at(j), 3, 3) =
+                jac_block.block(0, 6 + 3 * j, 3, 3);
+        }
+        jacobian.block(3 * i, 12, 3, 6) = jac_block.block(0, 0, 3, 6);
+    }
 }
 
 void QuadKD::getJacobianWorldAngVel(const Eigen::VectorXd &state,
                                     Eigen::MatrixXd &jacobian) const {
-  this->getJacobianBodyAngVel(state, jacobian);
+    this->getJacobianBodyAngVel(state, jacobian);
 
-  // RBDL uses Jacobian w.r.t. floating base angular velocity in body frame,
-  // which is multiplied by rotation matrix to map it to angular velocity in
-  // world frame here
-  for (size_t i = 0; i < 4; i++) {
-    Eigen::Matrix3d rot;
-    this->getRotationMatrix(state.segment(15, 3), rot);
-    jacobian.block(3 * i, 15, 3, 3) = jacobian.block(3 * i, 15, 3, 3) * rot;
-  }
+    // RBDL uses Jacobian w.r.t. floating base angular velocity in body frame,
+    // which is multiplied by rotation matrix to map it to angular velocity in
+    // world frame here
+    for (size_t i = 0; i < 4; i++) {
+        Eigen::Matrix3d rot;
+        this->getRotationMatrix(state.segment(15, 3), rot);
+        jacobian.block(3 * i, 15, 3, 3) = jacobian.block(3 * i, 15, 3, 3) * rot;
+    }
 }
 
 void QuadKD::getRotationMatrix(const Eigen::VectorXd &rpy,
                                Eigen::Matrix3d &rot) const {
-  rot = Eigen::AngleAxisd(rpy(2), Eigen::Vector3d::UnitZ()) *
-        Eigen::AngleAxisd(rpy(1), Eigen::Vector3d::UnitY()) *
-        Eigen::AngleAxisd(rpy(0), Eigen::Vector3d::UnitX());
+    rot = Eigen::AngleAxisd(rpy(2), Eigen::Vector3d::UnitZ()) *
+          Eigen::AngleAxisd(rpy(1), Eigen::Vector3d::UnitY()) *
+          Eigen::AngleAxisd(rpy(0), Eigen::Vector3d::UnitX());
 }
 
 void QuadKD::computeInverseDynamics(const Eigen::VectorXd &state_pos,
@@ -582,134 +589,140 @@ void QuadKD::computeInverseDynamics(const Eigen::VectorXd &state_pos,
                                     const Eigen::VectorXd &grf,
                                     const std::vector<int> &contact_mode,
                                     Eigen::VectorXd &tau) const {
-  // Convert q, q_dot into RBDL order
-  Eigen::VectorXd q(19), q_dot(18);
-  q.setZero();
-  q_dot.setZero();
+    // Convert q, q_dot into RBDL order
+    Eigen::VectorXd q(19), q_dot(18);
+    q.setZero();
+    q_dot.setZero();
 
-  q.head(3) = state_pos.segment(12, 3);
-  q_dot.head(3) = state_vel.segment(12, 3);
+    q.head(3) = state_pos.segment(12, 3);
+    q_dot.head(3) = state_vel.segment(12, 3);
 
-  tf2::Quaternion quat_tf;
-  quat_tf.setRPY(state_pos(15), state_pos(16), state_pos(17));
-  q(3) = quat_tf.getX();
-  q(4) = quat_tf.getY();
-  q(5) = quat_tf.getZ();
+    tf2::Quaternion quat_tf;
+    quat_tf.setRPY(state_pos(15), state_pos(16), state_pos(17));
+    q(3) = quat_tf.getX();
+    q(4) = quat_tf.getY();
+    q(5) = quat_tf.getZ();
 
-  // RBDL uses quaternion for floating base direction, but w is placed at the
-  // end of the state vector
-  q(18) = quat_tf.getW();
+    // RBDL uses quaternion for floating base direction, but w is placed at the
+    // end of the state vector
+    q(18) = quat_tf.getW();
 
-  q_dot.segment(3, 3) = state_vel.segment(15, 3);
+    q_dot.segment(3, 3) = state_vel.segment(15, 3);
 
-  for (size_t i = 0; i < leg_idx_list_.size(); i++) {
-    q.segment(6 + 3 * i, 3) = state_pos.segment(3 * leg_idx_list_.at(i), 3);
-    q_dot.segment(6 + 3 * i, 3) = state_vel.segment(3 * leg_idx_list_.at(i), 3);
-  }
-
-  // Compute jacobians
-  Eigen::MatrixXd jacobian = Eigen::MatrixXd::Zero(12, 18);
-  jacobian.setZero();
-  for (size_t i = 0; i < body_id_list_.size(); i++) {
-    Eigen::MatrixXd jac_block(3, 18);
-    jac_block.setZero();
-    RigidBodyDynamics::CalcPointJacobian(*model_, q, body_id_list_.at(i),
-                                         Eigen::Vector3d::Zero(), jac_block);
-    jacobian.block(3 * i, 0, 3, 18) = jac_block;
-  }
-
-  // Compute the equivalent force in generalized coordinates
-  Eigen::VectorXd tau_stance = -jacobian.transpose() * grf;
-
-  // Compute EOM
-  Eigen::MatrixXd M(18, 18);
-  M.setZero();
-  Eigen::VectorXd N(18);
-  RigidBodyDynamics::CompositeRigidBodyAlgorithm(*model_, q, M);
-  RigidBodyDynamics::NonlinearEffects(*model_, q, q_dot, N);
-
-  // Compute J_dot*q_dot
-  Eigen::VectorXd foot_acc_J_dot(12);
-  for (size_t i = 0; i < 4; i++) {
-    foot_acc_J_dot.segment(3 * i, 3) = RigidBodyDynamics::CalcPointAcceleration(
-        *model_, q, q_dot, Eigen::VectorXd::Zero(18), body_id_list_.at(i),
-        Eigen::Vector3d::Zero());
-  }
-
-  // Compute constraint Jacobian A and A_dot*q_dot
-  int constraints_num =
-      3 * std::count(contact_mode.begin(), contact_mode.end(), true);
-  Eigen::MatrixXd A(constraints_num, 18);
-  Eigen::VectorXd A_dotq_dot(constraints_num);
-  int constraints_count = 0;
-  for (size_t i = 0; i < 4; i++) {
-    if (contact_mode.at(i)) {
-      A.block(3 * constraints_count, 0, 3, 18) =
-          jacobian.block(3 * i, 0, 3, 18);
-      A_dotq_dot.segment(3 * constraints_count, 3) =
-          foot_acc_J_dot.segment(3 * i, 3);
-      constraints_count++;
+    for (size_t i = 0; i < leg_idx_list_.size(); i++) {
+        q.segment(6 + 3 * i, 3) = state_pos.segment(3 * leg_idx_list_.at(i), 3);
+        q_dot.segment(6 + 3 * i, 3) =
+            state_vel.segment(3 * leg_idx_list_.at(i), 3);
     }
-  }
 
-  // Compute acceleration from J*q_ddot
-  Eigen::VectorXd foot_acc_q_ddot = foot_acc - foot_acc_J_dot;
-
-  // Compuate damped jacobian inverser
-  Eigen::MatrixXd jacobian_inv =
-      math_utils::sdlsInv(jacobian.block(0, 6, 12, 12));
-
-  // In the EOM, we know M, N, tau_grf, and a = J_b*q_ddot_b + J_l*q_ddot_l, we
-  // need to solve q_ddot_b and tau_swing
-  Eigen::MatrixXd blk_mat =
-      Eigen::MatrixXd::Zero(18 + constraints_num, 18 + constraints_num);
-  blk_mat.block(0, 0, 6, 6) =
-      -M.block(0, 0, 6, 6) +
-      M.block(0, 6, 6, 12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
-  blk_mat.block(6, 0, 12, 6) =
-      -M.block(6, 0, 12, 6) +
-      M.block(6, 6, 12, 12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
-  for (size_t i = 0; i < 4; i++) {
-    if (!contact_mode.at(leg_idx_list_.at(i))) {
-      blk_mat.block(3 * i + 6, 3 * i + 6, 3, 3).diagonal().fill(1);
+    // Compute jacobians
+    Eigen::MatrixXd jacobian = Eigen::MatrixXd::Zero(12, 18);
+    jacobian.setZero();
+    for (size_t i = 0; i < body_id_list_.size(); i++) {
+        Eigen::MatrixXd jac_block(3, 18);
+        jac_block.setZero();
+        RigidBodyDynamics::CalcPointJacobian(*model_, q, body_id_list_.at(i),
+                                             Eigen::Vector3d::Zero(),
+                                             jac_block);
+        jacobian.block(3 * i, 0, 3, 18) = jac_block;
     }
-  }
-  blk_mat.block(0, 18, 18, constraints_num) = -A.transpose();
-  blk_mat.block(18, 0, constraints_num, 6) =
-      -A.leftCols(6) +
-      A.rightCols(12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
 
-  // Perform inverse dynamics
-  Eigen::VectorXd tau_swing(12), blk_sol(18 + constraints_num),
-      blk_vec(18 + constraints_num);
-  blk_vec.segment(0, 6) << N.segment(0, 6) + M.block(0, 6, 6, 12) *
-                                                 jacobian_inv * foot_acc_q_ddot;
-  blk_vec.segment(6, 12) << N.segment(6, 12) +
-                                M.block(6, 6, 12, 12) * jacobian_inv *
-                                    foot_acc_q_ddot -
-                                tau_stance.segment(6, 12);
-  blk_vec.segment(18, constraints_num)
-      << A_dotq_dot + A.leftCols(12) * jacobian_inv * foot_acc_q_ddot;
-  blk_sol =
-      blk_mat.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(blk_vec);
-  tau_swing = blk_sol.segment(6, 12);
+    // Compute the equivalent force in generalized coordinates
+    Eigen::VectorXd tau_stance = -jacobian.transpose() * grf;
 
-  // Convert the order back
-  for (size_t i = 0; i < 4; i++) {
-    if (contact_mode.at(leg_idx_list_.at(i))) {
-      tau.segment(3 * leg_idx_list_.at(i), 3) =
-          tau_stance.segment(6 + 3 * i, 3);
-    } else {
-      tau.segment(3 * leg_idx_list_.at(i), 3) = tau_swing.segment(3 * i, 3);
-      // tau.segment(3 * leg_idx_list_.at(i), 3) = Eigen::VectorXd::Zero(3);
+    // Compute EOM
+    Eigen::MatrixXd M(18, 18);
+    M.setZero();
+    Eigen::VectorXd N(18);
+    RigidBodyDynamics::CompositeRigidBodyAlgorithm(*model_, q, M);
+    RigidBodyDynamics::NonlinearEffects(*model_, q, q_dot, N);
+
+    // Compute J_dot*q_dot
+    Eigen::VectorXd foot_acc_J_dot(12);
+    for (size_t i = 0; i < 4; i++) {
+        foot_acc_J_dot.segment(3 * i, 3) =
+            RigidBodyDynamics::CalcPointAcceleration(
+                *model_, q, q_dot, Eigen::VectorXd::Zero(18),
+                body_id_list_.at(i), Eigen::Vector3d::Zero());
     }
-  }
 
-  // Check inf or nan
-  if (!(tau.array() == tau.array()).all() ||
-      !((tau - tau).array() == (tau - tau).array()).all()) {
-    tau.setZero();
-  }
+    // Compute constraint Jacobian A and A_dot*q_dot
+    int constraints_num =
+        3 * std::count(contact_mode.begin(), contact_mode.end(), true);
+    Eigen::MatrixXd A(constraints_num, 18);
+    Eigen::VectorXd A_dotq_dot(constraints_num);
+    int constraints_count = 0;
+    for (size_t i = 0; i < 4; i++) {
+        if (contact_mode.at(i)) {
+            A.block(3 * constraints_count, 0, 3, 18) =
+                jacobian.block(3 * i, 0, 3, 18);
+            A_dotq_dot.segment(3 * constraints_count, 3) =
+                foot_acc_J_dot.segment(3 * i, 3);
+            constraints_count++;
+        }
+    }
+
+    // Compute acceleration from J*q_ddot
+    Eigen::VectorXd foot_acc_q_ddot = foot_acc - foot_acc_J_dot;
+
+    // Compuate damped jacobian inverser
+    Eigen::MatrixXd jacobian_inv =
+        math_utils::sdlsInv(jacobian.block(0, 6, 12, 12));
+
+    // In the EOM, we know M, N, tau_grf, and a = J_b*q_ddot_b + J_l*q_ddot_l,
+    // we need to solve q_ddot_b and tau_swing
+    Eigen::MatrixXd blk_mat =
+        Eigen::MatrixXd::Zero(18 + constraints_num, 18 + constraints_num);
+    blk_mat.block(0, 0, 6, 6) =
+        -M.block(0, 0, 6, 6) +
+        M.block(0, 6, 6, 12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
+    blk_mat.block(6, 0, 12, 6) =
+        -M.block(6, 0, 12, 6) +
+        M.block(6, 6, 12, 12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
+    for (size_t i = 0; i < 4; i++) {
+        if (!contact_mode.at(leg_idx_list_.at(i))) {
+            blk_mat.block(3 * i + 6, 3 * i + 6, 3, 3).diagonal().fill(1);
+        }
+    }
+    blk_mat.block(0, 18, 18, constraints_num) = -A.transpose();
+    blk_mat.block(18, 0, constraints_num, 6) =
+        -A.leftCols(6) +
+        A.rightCols(12) * jacobian_inv * jacobian.block(0, 0, 12, 6);
+
+    // Perform inverse dynamics
+    Eigen::VectorXd tau_swing(12), blk_sol(18 + constraints_num),
+        blk_vec(18 + constraints_num);
+    blk_vec.segment(0, 6) << N.segment(0, 6) + M.block(0, 6, 6, 12) *
+                                                   jacobian_inv *
+                                                   foot_acc_q_ddot;
+    blk_vec.segment(6, 12) << N.segment(6, 12) +
+                                  M.block(6, 6, 12, 12) * jacobian_inv *
+                                      foot_acc_q_ddot -
+                                  tau_stance.segment(6, 12);
+    blk_vec.segment(18, constraints_num)
+        << A_dotq_dot + A.leftCols(12) * jacobian_inv * foot_acc_q_ddot;
+    blk_sol = blk_mat.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV)
+                  .solve(blk_vec);
+    tau_swing = blk_sol.segment(6, 12);
+
+    // Convert the order back
+    for (size_t i = 0; i < 4; i++) {
+        if (contact_mode.at(leg_idx_list_.at(i))) {
+            tau.segment(3 * leg_idx_list_.at(i), 3) =
+                tau_stance.segment(6 + 3 * i, 3);
+        } else {
+            tau.segment(3 * leg_idx_list_.at(i), 3) =
+                tau_swing.segment(3 * i, 3);
+            // tau.segment(3 * leg_idx_list_.at(i), 3) =
+            // Eigen::VectorXd::Zero(3);
+        }
+    }
+
+    // Check inf or nan
+    if (!(tau.array() == tau.array()).all() ||
+        !((tau - tau).array() == (tau - tau).array()).all()) {
+        tau.setZero();
+    }
 }
 
 bool QuadKD::convertCentroidalToFullBody(const Eigen::VectorXd &body_state,
@@ -719,95 +732,98 @@ bool QuadKD::convertCentroidalToFullBody(const Eigen::VectorXd &body_state,
                                          Eigen::VectorXd &joint_positions,
                                          Eigen::VectorXd &joint_velocities,
                                          Eigen::VectorXd &torques) {
-  // Assume the conversion is exact unless a check below fails
-  bool is_exact = true;
+    // Assume the conversion is exact unless a check below fails
+    bool is_exact = true;
 
-  // Extract kinematic quantities
-  Eigen::Vector3d body_pos = body_state.segment<3>(0);
-  Eigen::Vector3d body_rpy = body_state.segment<3>(3);
+    // Extract kinematic quantities
+    Eigen::Vector3d body_pos = body_state.segment<3>(0);
+    Eigen::Vector3d body_rpy = body_state.segment<3>(3);
 
-  auto t_start = std::chrono::steady_clock::now();
-  // Perform IK for each leg
-  for (int i = 0; i < num_feet_; i++) {
-    Eigen::Vector3d leg_joint_state;
-    Eigen::Vector3d foot_pos = foot_positions.segment<3>(3 * i);
-    is_exact = is_exact && worldToFootIKWorldFrame(i, body_pos, body_rpy,
-                                                   foot_pos, leg_joint_state);
-    joint_positions.segment<3>(3 * i) = leg_joint_state;
-  }
+    auto t_start = std::chrono::steady_clock::now();
+    // Perform IK for each leg
+    for (int i = 0; i < num_feet_; i++) {
+        Eigen::Vector3d leg_joint_state;
+        Eigen::Vector3d foot_pos = foot_positions.segment<3>(3 * i);
+        is_exact =
+            is_exact && worldToFootIKWorldFrame(i, body_pos, body_rpy, foot_pos,
+                                                leg_joint_state);
+        joint_positions.segment<3>(3 * i) = leg_joint_state;
+    }
 
-  auto t_ik = std::chrono::steady_clock::now();
+    auto t_ik = std::chrono::steady_clock::now();
 
-  // Load state positions
-  Eigen::VectorXd state_positions(18), state_velocities(18);
-  state_positions << joint_positions, body_pos, body_rpy;
+    // Load state positions
+    Eigen::VectorXd state_positions(18), state_velocities(18);
+    state_positions << joint_positions, body_pos, body_rpy;
 
-  // Compute jacobian
-  Eigen::MatrixXd jacobian = Eigen::MatrixXd::Zero(12, 18);
-  getJacobianBodyAngVel(state_positions, jacobian);
+    // Compute jacobian
+    Eigen::MatrixXd jacobian = Eigen::MatrixXd::Zero(12, 18);
+    getJacobianBodyAngVel(state_positions, jacobian);
 
-  auto t_jacob = std::chrono::steady_clock::now();
+    auto t_jacob = std::chrono::steady_clock::now();
 
-  // Compute joint velocities
-  joint_velocities = jacobian.leftCols(12).colPivHouseholderQr().solve(
-      foot_velocities - jacobian.rightCols(6) * body_state.tail(6));
-  state_velocities << joint_velocities, body_state.tail(6);
+    // Compute joint velocities
+    joint_velocities = jacobian.leftCols(12).colPivHouseholderQr().solve(
+        foot_velocities - jacobian.rightCols(6) * body_state.tail(6));
+    state_velocities << joint_velocities, body_state.tail(6);
 
-  auto t_ik_vel = std::chrono::steady_clock::now();
+    auto t_ik_vel = std::chrono::steady_clock::now();
 
-  torques = -jacobian.leftCols(12).transpose() * grfs;
+    torques = -jacobian.leftCols(12).transpose() * grfs;
 
-  // computeInverseDynamics(state_positions, state_velocities, foot_acc, grfs,
-  // contact_mode, torques);
+    // computeInverseDynamics(state_positions, state_velocities, foot_acc, grfs,
+    // contact_mode, torques);
 
-  auto t_id = std::chrono::steady_clock::now();
+    auto t_id = std::chrono::steady_clock::now();
 
-  std::chrono::duration<double> t_diff_ik =
-      std::chrono::duration_cast<std::chrono::duration<double>>(t_ik - t_start);
-  std::chrono::duration<double> t_diff_jacob =
-      std::chrono::duration_cast<std::chrono::duration<double>>(t_jacob - t_ik);
-  std::chrono::duration<double> t_diff_ik_vel =
-      std::chrono::duration_cast<std::chrono::duration<double>>(t_ik_vel -
-                                                                t_jacob);
-  std::chrono::duration<double> t_diff_id =
-      std::chrono::duration_cast<std::chrono::duration<double>>(t_id -
-                                                                t_ik_vel);
+    std::chrono::duration<double> t_diff_ik =
+        std::chrono::duration_cast<std::chrono::duration<double>>(t_ik -
+                                                                  t_start);
+    std::chrono::duration<double> t_diff_jacob =
+        std::chrono::duration_cast<std::chrono::duration<double>>(t_jacob -
+                                                                  t_ik);
+    std::chrono::duration<double> t_diff_ik_vel =
+        std::chrono::duration_cast<std::chrono::duration<double>>(t_ik_vel -
+                                                                  t_jacob);
+    std::chrono::duration<double> t_diff_id =
+        std::chrono::duration_cast<std::chrono::duration<double>>(t_id -
+                                                                  t_ik_vel);
 
-  // std::cout << "t_diff_ik = " << t_diff_ik.count() << std::endl;
-  // std::cout << "t_diff_jacob = " << t_diff_jacob.count() << std::endl;
-  // std::cout << "t_diff_ik_vel = " << t_diff_ik_vel.count() << std::endl;
-  // std::cout << "t_diff_id = " << t_diff_id.count() << std::endl;
+    // std::cout << "t_diff_ik = " << t_diff_ik.count() << std::endl;
+    // std::cout << "t_diff_jacob = " << t_diff_jacob.count() << std::endl;
+    // std::cout << "t_diff_ik_vel = " << t_diff_ik_vel.count() << std::endl;
+    // std::cout << "t_diff_id = " << t_diff_id.count() << std::endl;
 
-  return is_exact;
+    return is_exact;
 }
 
 bool QuadKD::applyMotorModel(const Eigen::VectorXd &torques,
                              Eigen::VectorXd &constrained_torques) {
-  // Constrain torques to max values
-  constrained_torques.resize(torques.size());
-  constrained_torques = torques.cwiseMax(-tau_max_).cwiseMin(tau_max_);
+    // Constrain torques to max values
+    constrained_torques.resize(torques.size());
+    constrained_torques = torques.cwiseMax(-tau_max_).cwiseMin(tau_max_);
 
-  // Check if torques was modified
-  return constrained_torques.isApprox(torques);
+    // Check if torques was modified
+    return constrained_torques.isApprox(torques);
 }
 
 bool QuadKD::applyMotorModel(const Eigen::VectorXd &joint_torques,
                              const Eigen::VectorXd &joint_velocities,
                              Eigen::VectorXd &constrained_joint_torques) {
-  // Constrain torques to max values
-  Eigen::VectorXd constraint_violation(joint_torques.size());
-  constrained_joint_torques.resize(joint_torques.size());
-  constrained_joint_torques =
-      joint_torques.cwiseMax(-tau_max_).cwiseMin(tau_max_);
+    // Constrain torques to max values
+    Eigen::VectorXd constraint_violation(joint_torques.size());
+    constrained_joint_torques.resize(joint_torques.size());
+    constrained_joint_torques =
+        joint_torques.cwiseMax(-tau_max_).cwiseMin(tau_max_);
 
-  // Apply linear motor model
-  Eigen::VectorXd emf = joint_velocities.cwiseProduct(mm_slope_);
-  constrained_joint_torques =
-      constrained_joint_torques.cwiseMax(-tau_max_ - emf)
-          .cwiseMin(tau_max_ - emf);
+    // Apply linear motor model
+    Eigen::VectorXd emf = joint_velocities.cwiseProduct(mm_slope_);
+    constrained_joint_torques =
+        constrained_joint_torques.cwiseMax(-tau_max_ - emf)
+            .cwiseMin(tau_max_ - emf);
 
-  // Check if torques were modified
-  return constrained_joint_torques.isApprox(joint_torques);
+    // Check if torques were modified
+    return constrained_joint_torques.isApprox(joint_torques);
 }
 
 bool QuadKD::isValidFullState(const Eigen::VectorXd &body_state,
@@ -816,28 +832,28 @@ bool QuadKD::isValidFullState(const Eigen::VectorXd &body_state,
                               const grid_map::GridMap &terrain,
                               Eigen::VectorXd &state_violation,
                               Eigen::VectorXd &control_violation) {
-  // Check state constraints
-  // Kinematics
-  state_violation.setZero(num_feet_);
-  for (int i = 0; i < num_feet_; i++) {
-    Eigen::Vector3d knee_pos_world;
-    worldToKneeFKWorldFrame(i, body_state.segment<3>(0),
-                            body_state.segment<3>(3),
-                            joint_state.segment<3>(3 * i), knee_pos_world);
-    state_violation[i] = getGroundClearance(knee_pos_world, terrain);
-  }
-  bool state_valid = (state_violation.array() >= 0).all();
+    // Check state constraints
+    // Kinematics
+    state_violation.setZero(num_feet_);
+    for (int i = 0; i < num_feet_; i++) {
+        Eigen::Vector3d knee_pos_world;
+        worldToKneeFKWorldFrame(i, body_state.segment<3>(0),
+                                body_state.segment<3>(3),
+                                joint_state.segment<3>(3 * i), knee_pos_world);
+        state_violation[i] = getGroundClearance(knee_pos_world, terrain);
+    }
+    bool state_valid = (state_violation.array() >= 0).all();
 
-  // Check control constraints
-  // Motor model
-  Eigen::VectorXd constrained_joint_torques(12);
-  bool control_valid = applyMotorModel(joint_torques, joint_state.tail(12),
-                                       constrained_joint_torques);
-  control_violation.setZero(joint_torques.size());
-  control_violation = -(constrained_joint_torques - joint_torques).cwiseAbs();
+    // Check control constraints
+    // Motor model
+    Eigen::VectorXd constrained_joint_torques(12);
+    bool control_valid = applyMotorModel(joint_torques, joint_state.tail(12),
+                                         constrained_joint_torques);
+    control_violation.setZero(joint_torques.size());
+    control_violation = -(constrained_joint_torques - joint_torques).cwiseAbs();
 
-  // Only valid if each subcheck is valid
-  return (state_valid && control_valid);
+    // Only valid if each subcheck is valid
+    return (state_valid && control_valid);
 }
 
 bool QuadKD::isValidCentroidalState(
@@ -846,15 +862,16 @@ bool QuadKD::isValidCentroidalState(
     const grid_map::GridMap &terrain, Eigen::VectorXd &joint_positions,
     Eigen::VectorXd &joint_velocities, Eigen::VectorXd &joint_torques,
     Eigen::VectorXd &state_violation, Eigen::VectorXd &control_violation) {
-  // Convert to full
-  bool is_exact = convertCentroidalToFullBody(
-      body_state, foot_positions, foot_velocities, grfs, joint_positions,
-      joint_velocities, joint_torques);
+    // Convert to full
+    bool is_exact = convertCentroidalToFullBody(
+        body_state, foot_positions, foot_velocities, grfs, joint_positions,
+        joint_velocities, joint_torques);
 
-  Eigen::VectorXd joint_state(24);
-  joint_state << joint_positions, joint_velocities;
-  bool is_valid = isValidFullState(body_state, joint_state, joint_torques,
-                                   terrain, state_violation, control_violation);
+    Eigen::VectorXd joint_state(24);
+    joint_state << joint_positions, joint_velocities;
+    bool is_valid =
+        isValidFullState(body_state, joint_state, joint_torques, terrain,
+                         state_violation, control_violation);
 
-  return (is_exact && is_valid);
+    return (is_exact && is_valid);
 }

--- a/quad_utils/src/quad_kd.cpp
+++ b/quad_utils/src/quad_kd.cpp
@@ -6,9 +6,9 @@ Eigen::IOFormat CleanFmt(4, 0, ", ", "\n", "[", "]");
 
 QuadKD::QuadKD() { initModel(""); }
 
-QuadKD::QuadKD(std::string ns) { initModel("/" + ns + "/"); }
+QuadKD::QuadKD(const std::string &ns) { initModel("/" + ns + "/"); }
 
-void QuadKD::initModel(std::string ns) {
+void QuadKD::initModel(const std::string &ns) {
   std::string robot_description_string;
 
   if (!ros::param::get("robot_description", robot_description_string)) {
@@ -97,8 +97,8 @@ void QuadKD::initModel(std::string ns) {
                 joint_max_back};
 }
 
-Eigen::Matrix4d QuadKD::createAffineMatrix(Eigen::Vector3d trans,
-                                           Eigen::Vector3d rpy) const {
+Eigen::Matrix4d QuadKD::createAffineMatrix(const Eigen::Vector3d &trans,
+                                           const Eigen::Vector3d &rpy) const {
   Eigen::Transform<double, 3, Eigen::Affine> t;
   t = Eigen::Translation<double, 3>(trans);
   t.rotate(Eigen::AngleAxisd(rpy[2], Eigen::Vector3d::UnitZ()));
@@ -108,8 +108,8 @@ Eigen::Matrix4d QuadKD::createAffineMatrix(Eigen::Vector3d trans,
   return t.matrix();
 }
 
-Eigen::Matrix4d QuadKD::createAffineMatrix(Eigen::Vector3d trans,
-                                           Eigen::AngleAxisd rot) const {
+Eigen::Matrix4d QuadKD::createAffineMatrix(const Eigen::Vector3d &trans,
+                                           const Eigen::AngleAxisd &rot) const {
   Eigen::Transform<double, 3, Eigen::Affine> t;
   t = Eigen::Translation<double, 3>(trans);
   t.rotate(rot);
@@ -138,9 +138,9 @@ double QuadKD::getLinkLength(int leg_index, int link_index) const {
   }
 }
 
-void QuadKD::transformBodyToWorld(Eigen::Vector3d body_pos,
-                                  Eigen::Vector3d body_rpy,
-                                  Eigen::Matrix4d transform_body,
+void QuadKD::transformBodyToWorld(const Eigen::Vector3d &body_pos,
+                                  const Eigen::Vector3d &body_rpy,
+                                  const Eigen::Matrix4d &transform_body,
                                   Eigen::Matrix4d &transform_world) const {
   // Compute transform from world to body frame
   Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
@@ -149,9 +149,9 @@ void QuadKD::transformBodyToWorld(Eigen::Vector3d body_pos,
   transform_world = g_world_body * transform_body;
 }
 
-void QuadKD::transformWorldToBody(Eigen::Vector3d body_pos,
-                                  Eigen::Vector3d body_rpy,
-                                  Eigen::Matrix4d transform_world,
+void QuadKD::transformWorldToBody(const Eigen::Vector3d &body_pos,
+                                  const Eigen::Vector3d &body_rpy,
+                                  const Eigen::Matrix4d &transform_world,
                                   Eigen::Matrix4d &transform_body) const {
   // Compute transform from world to body frame
   Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
@@ -161,7 +161,9 @@ void QuadKD::transformWorldToBody(Eigen::Vector3d body_pos,
 }
 
 void QuadKD::worldToLegbaseFKWorldFrame(
-    int leg_index, Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
+    int leg_index,
+    const Eigen::Vector3d &body_pos,
+    const Eigen::Vector3d &body_rpy,
     Eigen::Matrix4d &g_world_legbase) const {
   // Compute transforms
   Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
@@ -171,7 +173,9 @@ void QuadKD::worldToLegbaseFKWorldFrame(
 }
 
 void QuadKD::worldToLegbaseFKWorldFrame(
-    int leg_index, Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
+    int leg_index,
+    const Eigen::Vector3d &body_pos,
+    const Eigen::Vector3d &body_rpy,
     Eigen::Vector3d &leg_base_pos_world) const {
   Eigen::Matrix4d g_world_legbase;
   worldToLegbaseFKWorldFrame(leg_index, body_pos, body_rpy, g_world_legbase);
@@ -180,7 +184,9 @@ void QuadKD::worldToLegbaseFKWorldFrame(
 }
 
 void QuadKD::worldToNominalHipFKWorldFrame(
-    int leg_index, Eigen::Vector3d body_pos, Eigen::Vector3d body_rpy,
+    int leg_index,
+    const Eigen::Vector3d &body_pos,
+    const Eigen::Vector3d &body_rpy,
     Eigen::Vector3d &nominal_hip_pos_world) const {
   // Compute transforms
   Eigen::Matrix4d g_world_body = createAffineMatrix(body_pos, body_rpy);
@@ -194,7 +200,8 @@ void QuadKD::worldToNominalHipFKWorldFrame(
   nominal_hip_pos_world = g_world_nominal_hip.block<3, 1>(0, 3);
 }
 
-void QuadKD::bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
+void QuadKD::bodyToFootFKBodyFrame(int leg_index,
+                                   const Eigen::Vector3d &joint_state,
                                    Eigen::Matrix4d &g_body_foot) const {
   if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
     throw std::runtime_error("Leg index is outside valid range");
@@ -228,7 +235,8 @@ void QuadKD::bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
                 g_hip_knee * g_knee_foot;
 }
 
-void QuadKD::bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
+void QuadKD::bodyToFootFKBodyFrame(int leg_index,
+                                   const Eigen::Vector3d &joint_state,
                                    Eigen::Vector3d &foot_pos_body) const {
   Eigen::Matrix4d g_body_foot;
   QuadKD::bodyToFootFKBodyFrame(leg_index, joint_state, g_body_foot);
@@ -237,9 +245,10 @@ void QuadKD::bodyToFootFKBodyFrame(int leg_index, Eigen::Vector3d joint_state,
   foot_pos_body = g_body_foot.block<3, 1>(0, 3);
 }
 
-void QuadKD::worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                     Eigen::Vector3d body_rpy,
-                                     Eigen::Vector3d joint_state,
+void QuadKD::worldToFootFKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     const Eigen::Vector3d &joint_state,
                                      Eigen::Matrix4d &g_world_foot) const {
   if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
     throw std::runtime_error("Leg index is outside valid range");
@@ -278,9 +287,10 @@ void QuadKD::worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
       g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee * g_knee_foot;
 }
 
-void QuadKD::worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                     Eigen::Vector3d body_rpy,
-                                     Eigen::Vector3d joint_state,
+void QuadKD::worldToFootFKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     const Eigen::Vector3d &joint_state,
                                      Eigen::Vector3d &foot_pos_world) const {
   Eigen::Matrix4d g_world_foot;
   worldToFootFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
@@ -290,9 +300,10 @@ void QuadKD::worldToFootFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
   foot_pos_world = g_world_foot.block<3, 1>(0, 3);
 }
 
-void QuadKD::worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                     Eigen::Vector3d body_rpy,
-                                     Eigen::Vector3d joint_state,
+void QuadKD::worldToKneeFKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     const Eigen::Vector3d &joint_state,
                                      Eigen::Matrix4d &g_world_knee) const {
   if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
     throw std::runtime_error("Leg index is outside valid range");
@@ -326,9 +337,10 @@ void QuadKD::worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
   g_world_knee = g_world_legbase * g_legbase_abad * g_abad_hip * g_hip_knee;
 }
 
-void QuadKD::worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                     Eigen::Vector3d body_rpy,
-                                     Eigen::Vector3d joint_state,
+void QuadKD::worldToKneeFKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     const Eigen::Vector3d &joint_state,
                                      Eigen::Vector3d &knee_pos_world) const {
   Eigen::Matrix4d g_world_knee;
   worldToKneeFKWorldFrame(leg_index, body_pos, body_rpy, joint_state,
@@ -338,9 +350,10 @@ void QuadKD::worldToKneeFKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
   knee_pos_world = g_world_knee.block<3, 1>(0, 3);
 }
 
-bool QuadKD::worldToFootIKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
-                                     Eigen::Vector3d body_rpy,
-                                     Eigen::Vector3d foot_pos_world,
+bool QuadKD::worldToFootIKWorldFrame(int leg_index,
+                                     const Eigen::Vector3d &body_pos,
+                                     const Eigen::Vector3d &body_rpy,
+                                     const Eigen::Vector3d &foot_pos_world,
                                      Eigen::Vector3d &joint_state) const {
   if (leg_index > (legbase_offsets_.size() - 1) || leg_index < 0) {
     throw std::runtime_error("Leg index is outside valid range");
@@ -370,7 +383,7 @@ bool QuadKD::worldToFootIKWorldFrame(int leg_index, Eigen::Vector3d body_pos,
 }
 
 bool QuadKD::legbaseToFootIKLegbaseFrame(int leg_index,
-                                         Eigen::Vector3d foot_pos_legbase,
+                                         const Eigen::Vector3d &foot_pos_legbase,
                                          Eigen::Vector3d &joint_state) const {
   // Initialize exact bool
   bool is_exact = true;

--- a/robot_driver/src/robot_driver.cpp
+++ b/robot_driver/src/robot_driver.cpp
@@ -1,4 +1,7 @@
 #include "robot_driver/robot_driver.h"
+// New comments to test David's stuff
+// 10/06/2023 @ 15:25
+
 
 RobotDriver::RobotDriver(ros::NodeHandle nh, int argc, char **argv) {
   nh_ = nh;


### PR DESCRIPTION
Addresses #212 (finally) by adding const ref arguments to most utility functions in math_utils, ros_utils, and QuadKD. Not a huge effect on overall performance (interpRobotState takes about 1us instead of 5us), but nice to have. May help other controllers that require more kinematics queries.